### PR TITLE
Fix default consumption for PowerCommand

### DIFF
--- a/src/main/java/think/rpgitems/power/PowerArrow.java
+++ b/src/main/java/think/rpgitems/power/PowerArrow.java
@@ -72,7 +72,7 @@ public class PowerArrow extends Power implements PowerRightClick, PowerConsuming
     @Override
     public void init(ConfigurationSection s) {
         cooldownTime = s.getLong("cooldown", 20);
-        consumption = s.getInt("consumption", 0);
+        consumption = s.getInt("consumption", 1);
     }
 
     @Override

--- a/src/main/java/think/rpgitems/power/PowerCommand.java
+++ b/src/main/java/think/rpgitems/power/PowerCommand.java
@@ -117,7 +117,7 @@ public class PowerCommand extends Power implements PowerRightClick, PowerLeftCli
         display = s.getString("display", "");
         isRight = s.getBoolean("isRight", true);
         permission = s.getString("permission", "");
-        consumption = s.getInt("consumption", 1);
+        consumption = s.getInt("consumption", 0);
     }
 
     @Override

--- a/src/main/java/think/rpgitems/power/PowerFireball.java
+++ b/src/main/java/think/rpgitems/power/PowerFireball.java
@@ -70,7 +70,7 @@ public class PowerFireball extends Power implements PowerRightClick, PowerConsum
     @Override
     public void init(ConfigurationSection s) {
         cooldownTime = s.getLong("cooldown", 20);
-        consumption = s.getInt("consumption", 0);
+        consumption = s.getInt("consumption", 1);
     }
 
     @Override

--- a/src/main/java/think/rpgitems/power/PowerProjectile.java
+++ b/src/main/java/think/rpgitems/power/PowerProjectile.java
@@ -32,7 +32,7 @@ public class PowerProjectile extends Power implements PowerRightClick, PowerCons
         cone = s.getBoolean("isCone");
         range = s.getInt("range");
         amount = s.getInt("amount");
-        consumption = s.getInt("consumption", 0);
+        consumption = s.getInt("consumption", 1);
     }
 
     @Override

--- a/src/main/java/think/rpgitems/power/PowerTippedArrow.java
+++ b/src/main/java/think/rpgitems/power/PowerTippedArrow.java
@@ -80,7 +80,7 @@ public class PowerTippedArrow extends Power implements PowerRightClick {
         amplifier = s.getInt("amplifier", 15);
         String potionEffectName = s.getString("type", "HARM");
         type = PotionEffectType.getByName(potionEffectName);
-        consumption = s.getInt("consumption", 0);
+        consumption = s.getInt("consumption", 1);
     }
 
     @Override


### PR DESCRIPTION
刚刚意识到一个小问题，所有的航炮类的东西的耐久消耗都要手动设一下……或者我设一下PowerArrow的默认为1？