### PR TITLE
Delayed command feature

### DIFF
--- a/src/main/java/think/rpgitems/power/PowerAOE.java
+++ b/src/main/java/think/rpgitems/power/PowerAOE.java
@@ -52,31 +52,36 @@ public class PowerAOE extends Power implements PowerRightClick {
     @Property(order = 0)
     public long cooldownTime = 20;
     /**
-     * Amplifier of the potion
-     */
-    @Property(order = 4, required = true)
-    public int amplifier = 1;
-    /**
-     * Duration of the potion
-     */
-    @Property(order = 3)
-    public int duration = 15;
-    /**
      * Range of the potion
      */
     @Property(order = 1)
     public int range = 5;
-    /**
-     * Whether the potion will be apply to the user
-     */
-    @Property(order = 5)
-    public boolean selfapplication = true;
     /**
      * Type of the potion
      */
     @Property(order = 2)
     @Setter("setType")
     public PotionEffectType type;
+    /**
+     * Duration of the potion
+     */
+    @Property(order = 3)
+    public int duration = 15;
+    /**
+     * Amplifier of the potion
+     */
+    @Property(order = 4, required = true)
+    public int amplifier = 1;
+    /**
+     * Whether the potion will be apply to the user
+     */
+    @Property(order = 5)
+    public boolean selfapplication = true;
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 6)
+    public int delay = 0;
     /**
      * Display text of this power. Will use default text in case of null
      */
@@ -87,11 +92,6 @@ public class PowerAOE extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
-    /**
-     * delay before power activate.
-     */
-    @Property(order = 0)
-    public int delay = 0;
 
     @Override
     public void init(ConfigurationSection s) {

--- a/src/main/java/think/rpgitems/power/PowerAOECommand.java
+++ b/src/main/java/think/rpgitems/power/PowerAOECommand.java
@@ -6,6 +6,8 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
+import think.rpgitems.RPGItems;
 import think.rpgitems.commands.Property;
 
 import java.util.List;
@@ -58,6 +60,12 @@ public class PowerAOECommand extends PowerCommand {
      */
     @Property
     public int c = 100;
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
+
 
     /**
      * Whether only apply to the entities that player have line of sight
@@ -125,7 +133,12 @@ public class PowerAOECommand extends PowerCommand {
         if (!item.checkPermission(player, true)) return;
         if (!isRight || !checkCooldownByString(player, item, command, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
-        aoeCommand(player);
+        new BukkitRunnable(){
+            @Override
+            public void run() {
+                aoeCommand(player);
+            }
+        }.runTaskLater(RPGItems.plugin,delay);
     }
 
     @Override
@@ -133,7 +146,12 @@ public class PowerAOECommand extends PowerCommand {
         if (!item.checkPermission(player, true)) return;
         if (isRight || !checkCooldownByString(player, item, command, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
-        aoeCommand(player);
+        new BukkitRunnable(){
+            @Override
+            public void run() {
+                aoeCommand(player);
+            }
+        }.runTaskLater(RPGItems.plugin,delay);
     }
 
     @Override
@@ -145,6 +163,7 @@ public class PowerAOECommand extends PowerCommand {
         c = s.getInt("c", 100);
         selfapplication = s.getBoolean("selfapplication", false);
         mustsee = s.getBoolean("mustsee", mustsee);
+        delay = s.getInt("delay",0);
         super.init(s);
     }
 
@@ -157,6 +176,7 @@ public class PowerAOECommand extends PowerCommand {
         s.set("c", c);
         s.set("selfapplication", selfapplication);
         s.set("mustsee", mustsee);
+        s.set("delay",delay);
         super.save(s);
     }
 }

--- a/src/main/java/think/rpgitems/power/PowerAOECommand.java
+++ b/src/main/java/think/rpgitems/power/PowerAOECommand.java
@@ -54,17 +54,17 @@ public class PowerAOECommand extends PowerCommand {
      */
     @Property(order = 7, required = true)
     public double facing = 30;
-
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 8)
+    public int delay = 0;
     /**
      * Maximum count
      */
     @Property
     public int c = 100;
-    /**
-     * delay before power activate.
-     */
-    @Property(order = 0)
-    public int delay = 0;
+
 
 
     /**

--- a/src/main/java/think/rpgitems/power/PowerArrow.java
+++ b/src/main/java/think/rpgitems/power/PowerArrow.java
@@ -45,12 +45,14 @@ public class PowerArrow extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
 
     @Override
     public void rightClick(Player player, ItemStack stack, Block clicked) {
         if (!item.checkPermission(player, true)) return;
         if (!checkCooldown(player, cooldownTime, true)) return;
-        if (!item.consumeDurability(stack, consumption)) return;
+        if (!item.consumeDurability(stack, consumption)) return;    //TODO:ADD delay.
+
         player.playSound(player.getLocation(), Sound.ENTITY_ARROW_SHOOT, 1.0f, 1.0f);
         Arrow arrow = player.launchProjectile(Arrow.class);
         Events.rpgProjectiles.put(arrow.getEntityId(), item.getID());
@@ -70,13 +72,15 @@ public class PowerArrow extends Power implements PowerRightClick {
     @Override
     public void init(ConfigurationSection s) {
         cooldownTime = s.getLong("cooldown", 20);
-        consumption = s.getInt("consumption", 1);
+        consumption = s.getInt("consumption", 1);    //TODO:ADD delay.
+
     }
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("cooldown", cooldownTime);
-        s.set("consumption", consumption);
+        s.set("consumption", consumption);    //TODO:ADD delay.
+
     }
 
 }

--- a/src/main/java/think/rpgitems/power/PowerArrow.java
+++ b/src/main/java/think/rpgitems/power/PowerArrow.java
@@ -43,15 +43,16 @@ public class PowerArrow extends Power implements PowerRightClick {
     @Property(order = 0)
     public long cooldownTime = 20;
     /**
+     * delay before power activate.
+     */
+    @Property(order = 1)
+    public int delay = 0;
+    /**
      * Cost of this power
      */
     @Property
     public int consumption = 0;
-    /**
-     * delay before power activate.
-     */
-    @Property(order = 0)
-    public int delay = 0;
+
 
     @Override
     public void rightClick(Player player, ItemStack stack, Block clicked) {

--- a/src/main/java/think/rpgitems/power/PowerColor.java
+++ b/src/main/java/think/rpgitems/power/PowerColor.java
@@ -90,6 +90,7 @@ public class PowerColor extends Power implements PowerRightClick, PowerLeftClick
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
 
     @SuppressWarnings("deprecation")
     @Override
@@ -130,7 +131,8 @@ public class PowerColor extends Power implements PowerRightClick, PowerLeftClick
 
     @Override
     public void leftClick(Player player, ItemStack stack, Block clicked) {
-        if (!item.checkPermission(player, true)) return;
+        if (!item.checkPermission(player, true)) return;    //TODO:ADD delay.
+
         RPGValue value = RPGValue.get(player, item, "color.current");
         if (value == null) {
             new RPGValue(player, item, "color.current", 0);
@@ -157,7 +159,8 @@ public class PowerColor extends Power implements PowerRightClick, PowerLeftClick
         glass = s.getBoolean("glass", true);
         wool = s.getBoolean("wool", true);
         clay = s.getBoolean("clay", true);
-        consumption = s.getInt("consumption", 0);
+        consumption = s.getInt("consumption", 0);    //TODO:ADD delay.
+
     }
 
     @Override
@@ -166,7 +169,8 @@ public class PowerColor extends Power implements PowerRightClick, PowerLeftClick
         s.set("glass", glass);
         s.set("clay", clay);
         s.set("wool", wool);
-        s.set("consumption", consumption);
+        s.set("consumption", consumption);    //TODO:ADD delay.
+
     }
 
 }

--- a/src/main/java/think/rpgitems/power/PowerColor.java
+++ b/src/main/java/think/rpgitems/power/PowerColor.java
@@ -88,15 +88,16 @@ public class PowerColor extends Power implements PowerRightClick, PowerLeftClick
     @Property(order = 3)
     public boolean wool = true;
     /**
+     * delay before power activate.
+     */
+    @Property(order = 4)
+    public int delay = 0;
+    /**
      * Cost of this power
      */
     @Property
     public int consumption = 0;
-    /**
-     * delay before power activate.
-     */
-    @Property(order = 0)
-    public int delay = 0;
+
 
     @SuppressWarnings("deprecation")
     @Override

--- a/src/main/java/think/rpgitems/power/PowerColor.java
+++ b/src/main/java/think/rpgitems/power/PowerColor.java
@@ -23,7 +23,9 @@ import org.bukkit.block.Block;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
 import think.rpgitems.I18n;
+import think.rpgitems.RPGItems;
 import think.rpgitems.commands.Property;
 import think.rpgitems.data.RPGValue;
 import think.rpgitems.power.types.PowerLeftClick;
@@ -90,49 +92,59 @@ public class PowerColor extends Power implements PowerRightClick, PowerLeftClick
      */
     @Property
     public int consumption = 0;
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
 
     @SuppressWarnings("deprecation")
     @Override
     public void rightClick(Player player, ItemStack stack, Block clicked) {
-        if (clicked == null)
-            return;
-        if (!WorldGuard.canBuild(player, clicked.getLocation()))
-            return;
-        if (clicked.getType().toString().contains("GLASS")) {
-            if (!glass)
-                return;
-        } else if (clicked.getType().toString().contains("CLAY")) {
-            if (!clay)
-                return;
-        } else if (clicked.getType().equals(Material.WOOL)) {
-            if (!wool)
-                return;
-        } else {
-            return;
-        }
+        new BukkitRunnable(){
+            @Override
+            public void run() {
+                if (clicked == null)
+                    return;
+                if (!WorldGuard.canBuild(player, clicked.getLocation()))
+                    return;
+                if (clicked.getType().toString().contains("GLASS")) {
+                    if (!glass)
+                        return;
+                } else if (clicked.getType().toString().contains("CLAY")) {
+                    if (!clay)
+                        return;
+                } else if (clicked.getType().equals(Material.WOOL)) {
+                    if (!wool)
+                        return;
+                } else {
+                    return;
+                }
 
-        if (!item.checkPermission(player, true)) return;
-        if (!checkCooldown(player, cooldownTime, true)) return;
-        if (!item.consumeDurability(stack, consumption)) return;
-        RPGValue color = RPGValue.get(player, item, "color.current");
-        if (color == null) {
-            color = new RPGValue(player, item, "color.current", 0);
-        }
-        if (clicked.getType().equals(Material.GLASS))
-            clicked.setType(Material.STAINED_GLASS);
-        if (clicked.getType().equals(Material.THIN_GLASS))
-            clicked.setType(Material.STAINED_GLASS_PANE);
-        if (clicked.getType().equals(Material.CLAY) || clicked.getType().equals(Material.HARD_CLAY))
-            clicked.setType(Material.STAINED_CLAY);
+                if (!item.checkPermission(player, true)) return;
+                if (!checkCooldown(player, cooldownTime, true)) return;
+                if (!item.consumeDurability(stack, consumption)) return;
+                RPGValue color = RPGValue.get(player, item, "color.current");
+                if (color == null) {
+                    color = new RPGValue(player, item, "color.current", 0);
+                }
+                if (clicked.getType().equals(Material.GLASS))
+                    clicked.setType(Material.STAINED_GLASS);
+                if (clicked.getType().equals(Material.THIN_GLASS))
+                    clicked.setType(Material.STAINED_GLASS_PANE);
+                if (clicked.getType().equals(Material.CLAY) || clicked.getType().equals(Material.HARD_CLAY))
+                    clicked.setType(Material.STAINED_CLAY);
 
-        clicked.setData(DyeColor.values()[color.asInt()].getDyeData());
+                clicked.setData(DyeColor.values()[color.asInt()].getDyeData());
+            }
+        }.runTaskLater(RPGItems.plugin,delay);
+
+
     }
 
     @Override
     public void leftClick(Player player, ItemStack stack, Block clicked) {
-        if (!item.checkPermission(player, true)) return;    //TODO:ADD delay.
-
+        if (!item.checkPermission(player, true)) return;
         RPGValue value = RPGValue.get(player, item, "color.current");
         if (value == null) {
             new RPGValue(player, item, "color.current", 0);
@@ -159,8 +171,8 @@ public class PowerColor extends Power implements PowerRightClick, PowerLeftClick
         glass = s.getBoolean("glass", true);
         wool = s.getBoolean("wool", true);
         clay = s.getBoolean("clay", true);
-        consumption = s.getInt("consumption", 0);    //TODO:ADD delay.
-
+        consumption = s.getInt("consumption", 0);
+        delay = s.getInt("delay");
     }
 
     @Override
@@ -169,7 +181,8 @@ public class PowerColor extends Power implements PowerRightClick, PowerLeftClick
         s.set("glass", glass);
         s.set("clay", clay);
         s.set("wool", wool);
-        s.set("consumption", consumption);    //TODO:ADD delay.
+        s.set("consumption", consumption);
+        s.set("delay",delay);
 
     }
 

--- a/src/main/java/think/rpgitems/power/PowerCommand.java
+++ b/src/main/java/think/rpgitems/power/PowerCommand.java
@@ -21,6 +21,8 @@ import org.bukkit.block.Block;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
+import think.rpgitems.RPGItems;
 import think.rpgitems.commands.Property;
 import think.rpgitems.commands.BooleanChoice;
 import think.rpgitems.power.types.PowerLeftClick;
@@ -67,12 +69,17 @@ public class PowerCommand extends Power implements PowerRightClick, PowerLeftCli
      */
     @Property
     public int consumption = 0;
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
 
     /**
      * Execute command
      *
      * @param player player
-     */    //TODO:ADD delay.
+     */
 
     protected void executeCommand(Player player) {
         if (!player.isOnline()) return;
@@ -95,7 +102,12 @@ public class PowerCommand extends Power implements PowerRightClick, PowerLeftCli
         if (!item.checkPermission(player, true)) return;
         if (!isRight || !checkCooldownByString(player, item, command, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
-        executeCommand(player);    //TODO:ADD delay.
+        new BukkitRunnable(){
+            @Override
+            public void run() {
+                executeCommand(player);
+            }
+        }.runTaskLater(RPGItems.plugin,delay);
 
     }
 
@@ -104,7 +116,12 @@ public class PowerCommand extends Power implements PowerRightClick, PowerLeftCli
         if (!item.checkPermission(player, true)) return;
         if (isRight || !checkCooldownByString(player, item, command, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
-        executeCommand(player);    //TODO:ADD delay.
+        new BukkitRunnable(){
+            @Override
+            public void run() {
+                executeCommand(player);
+            }
+        }.runTaskLater(RPGItems.plugin,delay);
 
     }
 
@@ -125,7 +142,8 @@ public class PowerCommand extends Power implements PowerRightClick, PowerLeftCli
         display = s.getString("display", "");
         isRight = s.getBoolean("isRight", true);
         permission = s.getString("permission", "");
-        consumption = s.getInt("consumption", 0);    //TODO:ADD delay.
+        consumption = s.getInt("consumption", 0);
+        delay = s.getInt("delay");
 
     }
 
@@ -137,7 +155,8 @@ public class PowerCommand extends Power implements PowerRightClick, PowerLeftCli
         s.set("isRight", isRight);
         s.set("permission", permission);
         s.set("consumption", consumption);
-    }    //TODO:ADD delay.
+        s.set("delay",delay);
+    }
 
 
 }

--- a/src/main/java/think/rpgitems/power/PowerCommand.java
+++ b/src/main/java/think/rpgitems/power/PowerCommand.java
@@ -72,7 +72,8 @@ public class PowerCommand extends Power implements PowerRightClick, PowerLeftCli
      * Execute command
      *
      * @param player player
-     */
+     */    //TODO:ADD delay.
+
     protected void executeCommand(Player player) {
         if (!player.isOnline()) return;
 
@@ -94,7 +95,8 @@ public class PowerCommand extends Power implements PowerRightClick, PowerLeftCli
         if (!item.checkPermission(player, true)) return;
         if (!isRight || !checkCooldownByString(player, item, command, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
-        executeCommand(player);
+        executeCommand(player);    //TODO:ADD delay.
+
     }
 
     @Override
@@ -102,7 +104,8 @@ public class PowerCommand extends Power implements PowerRightClick, PowerLeftCli
         if (!item.checkPermission(player, true)) return;
         if (isRight || !checkCooldownByString(player, item, command, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
-        executeCommand(player);
+        executeCommand(player);    //TODO:ADD delay.
+
     }
 
     @Override
@@ -122,7 +125,8 @@ public class PowerCommand extends Power implements PowerRightClick, PowerLeftCli
         display = s.getString("display", "");
         isRight = s.getBoolean("isRight", true);
         permission = s.getString("permission", "");
-        consumption = s.getInt("consumption", 0);
+        consumption = s.getInt("consumption", 0);    //TODO:ADD delay.
+
     }
 
     @Override
@@ -133,6 +137,7 @@ public class PowerCommand extends Power implements PowerRightClick, PowerLeftCli
         s.set("isRight", isRight);
         s.set("permission", permission);
         s.set("consumption", consumption);
-    }
+    }    //TODO:ADD delay.
+
 
 }

--- a/src/main/java/think/rpgitems/power/PowerCommandHit.java
+++ b/src/main/java/think/rpgitems/power/PowerCommandHit.java
@@ -71,7 +71,7 @@ public class PowerCommandHit extends Power implements PowerHit {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 4)
     public int delay = 0;
 
     /**

--- a/src/main/java/think/rpgitems/power/PowerCommandHit.java
+++ b/src/main/java/think/rpgitems/power/PowerCommandHit.java
@@ -66,6 +66,7 @@ public class PowerCommandHit extends Power implements PowerHit {
      */
     @Property
     public double minDamage = 0;
+    //TODO:ADD delay.
 
     /**
      * Execute command
@@ -108,6 +109,7 @@ public class PowerCommandHit extends Power implements PowerHit {
         if (!item.checkPermission(player, true)) return;
         if (!checkCooldownByString(player, item, command, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
+        //TODO:ADD delay.
 
         executeCommand(player, entity);
     }
@@ -130,7 +132,8 @@ public class PowerCommandHit extends Power implements PowerHit {
         permission = s.getString("permission", "");
         consumption = s.getInt("consumption", 0);
         minDamage = s.getInt("minDamage", 0);
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public void save(ConfigurationSection s) {
@@ -139,6 +142,7 @@ public class PowerCommandHit extends Power implements PowerHit {
         s.set("display", display);
         s.set("permission", permission);
         s.set("minDamage", minDamage);
-        s.set("consumption", consumption);
+        s.set("consumption", consumption);    //TODO:ADD delay.
+
     }
 }

--- a/src/main/java/think/rpgitems/power/PowerCommandHit.java
+++ b/src/main/java/think/rpgitems/power/PowerCommandHit.java
@@ -22,6 +22,8 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
+import think.rpgitems.RPGItems;
 import think.rpgitems.commands.Property;
 import think.rpgitems.power.types.PowerHit;
 
@@ -66,7 +68,11 @@ public class PowerCommandHit extends Power implements PowerHit {
      */
     @Property
     public double minDamage = 0;
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
 
     /**
      * Execute command
@@ -109,9 +115,12 @@ public class PowerCommandHit extends Power implements PowerHit {
         if (!item.checkPermission(player, true)) return;
         if (!checkCooldownByString(player, item, command, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
-        //TODO:ADD delay.
-
-        executeCommand(player, entity);
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                executeCommand(player, entity);
+            }
+        }.runTaskLater(RPGItems.plugin,delay);
     }
 
     @Override
@@ -132,7 +141,8 @@ public class PowerCommandHit extends Power implements PowerHit {
         permission = s.getString("permission", "");
         consumption = s.getInt("consumption", 0);
         minDamage = s.getInt("minDamage", 0);
-    }    //TODO:ADD delay.
+        delay = s.getInt("delay");
+    }
 
 
     @Override
@@ -142,7 +152,8 @@ public class PowerCommandHit extends Power implements PowerHit {
         s.set("display", display);
         s.set("permission", permission);
         s.set("minDamage", minDamage);
-        s.set("consumption", consumption);    //TODO:ADD delay.
+        s.set("consumption", consumption);
+        s.set("delay",delay);
 
     }
 }

--- a/src/main/java/think/rpgitems/power/PowerConsume.java
+++ b/src/main/java/think/rpgitems/power/PowerConsume.java
@@ -54,20 +54,22 @@ public class PowerConsume extends Power implements PowerRightClick, PowerLeftCli
      */
     @Property
     public int consumption = 0;
-
+    //TODO:ADD delay.
     @Override
     public void rightClick(final Player player, ItemStack stack, Block clicked) {
         if (!item.checkPermission(player, true)) return;
         if (isRight && checkCooldown(player, cooldownTime, false)) {
             consume(player);
-        }
+        }    //TODO:ADD delay.
+
     }
 
     @Override
     public void leftClick(final Player player, ItemStack stack, Block clicked) {
         if (!item.checkPermission(player, true)) return;
         if (!isRight && checkCooldown(player, cooldownTime, false)) {
-            consume(player);
+            consume(player);    //TODO:ADD delay.
+
         }
     }
 
@@ -91,14 +93,16 @@ public class PowerConsume extends Power implements PowerRightClick, PowerLeftCli
     public void init(ConfigurationSection s) {
         cooldownTime = s.getInt("cooldown", 0);
         isRight = s.getBoolean("isRight", true);
-        consumption = s.getInt("consumption", 0);
+        //TODO:ADD delay.
+
     }
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("cooldown", cooldownTime);
         s.set("isRight", isRight);
-        s.set("consumption", consumption);
+        s.set("consumption", consumption);    //TODO:ADD delay.
+
     }
 
     @Override

--- a/src/main/java/think/rpgitems/power/PowerConsume.java
+++ b/src/main/java/think/rpgitems/power/PowerConsume.java
@@ -54,13 +54,14 @@ public class PowerConsume extends Power implements PowerRightClick, PowerLeftCli
      */
     @Property
     public int consumption = 0;
-    //TODO:ADD delay.
+
+
     @Override
     public void rightClick(final Player player, ItemStack stack, Block clicked) {
         if (!item.checkPermission(player, true)) return;
         if (isRight && checkCooldown(player, cooldownTime, false)) {
             consume(player);
-        }    //TODO:ADD delay.
+        }
 
     }
 
@@ -68,7 +69,7 @@ public class PowerConsume extends Power implements PowerRightClick, PowerLeftCli
     public void leftClick(final Player player, ItemStack stack, Block clicked) {
         if (!item.checkPermission(player, true)) return;
         if (!isRight && checkCooldown(player, cooldownTime, false)) {
-            consume(player);    //TODO:ADD delay.
+            consume(player);
 
         }
     }
@@ -93,16 +94,13 @@ public class PowerConsume extends Power implements PowerRightClick, PowerLeftCli
     public void init(ConfigurationSection s) {
         cooldownTime = s.getInt("cooldown", 0);
         isRight = s.getBoolean("isRight", true);
-        //TODO:ADD delay.
-
     }
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("cooldown", cooldownTime);
         s.set("isRight", isRight);
-        s.set("consumption", consumption);    //TODO:ADD delay.
-
+        s.set("consumption", consumption);
     }
 
     @Override

--- a/src/main/java/think/rpgitems/power/PowerConsumeHit.java
+++ b/src/main/java/think/rpgitems/power/PowerConsumeHit.java
@@ -37,7 +37,7 @@ public class PowerConsumeHit extends Power implements PowerHit {
      */
     @Property(order = 0)
     public int cooldownTime = 0;
-    //TODO:ADD delay.
+
     @Override
     public void hit(final Player player, ItemStack stack, LivingEntity entity, double damage) {
         if (!checkCooldown(player, cooldownTime, false)) return;
@@ -54,13 +54,14 @@ public class PowerConsumeHit extends Power implements PowerHit {
     @Override
     public void init(ConfigurationSection s) {
         cooldownTime = s.getInt("cooldown", 0);
-    }    //TODO:ADD delay.
+
+    }
 
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("cooldown", cooldownTime);
-    }    //TODO:ADD delay.
+    }
 
 
     @Override

--- a/src/main/java/think/rpgitems/power/PowerConsumeHit.java
+++ b/src/main/java/think/rpgitems/power/PowerConsumeHit.java
@@ -37,7 +37,7 @@ public class PowerConsumeHit extends Power implements PowerHit {
      */
     @Property(order = 0)
     public int cooldownTime = 0;
-
+    //TODO:ADD delay.
     @Override
     public void hit(final Player player, ItemStack stack, LivingEntity entity, double damage) {
         if (!checkCooldown(player, cooldownTime, false)) return;
@@ -54,12 +54,14 @@ public class PowerConsumeHit extends Power implements PowerHit {
     @Override
     public void init(ConfigurationSection s) {
         cooldownTime = s.getInt("cooldown", 0);
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("cooldown", cooldownTime);
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public String getName() {

--- a/src/main/java/think/rpgitems/power/PowerDeathCommand.java
+++ b/src/main/java/think/rpgitems/power/PowerDeathCommand.java
@@ -49,6 +49,8 @@ public class PowerDeathCommand extends Power implements PowerHit {
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
+    //TODO:ADD delay.
 
     @Override
     public void init(ConfigurationSection s) {
@@ -56,7 +58,8 @@ public class PowerDeathCommand extends Power implements PowerHit {
         chance = s.getInt("chance");
         desc = s.getString("desc");
         count = s.getInt("count");
-        consumption = s.getInt("consumption", 0);
+        consumption = s.getInt("consumption", 0);    //    //TODO:ADD delay.
+
     }
 
     @Override
@@ -66,7 +69,8 @@ public class PowerDeathCommand extends Power implements PowerHit {
         s.set("desc", desc);
         s.set("count", count);
         s.set("consumption", consumption);
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public String getName() {
@@ -91,6 +95,7 @@ public class PowerDeathCommand extends Power implements PowerHit {
             String cmd = command.replace("${x}", String.valueOf(x)).replace("${y}", String.valueOf(y)).replace("${z}", String.valueOf(z));
             for (int i = 0; i < count; i++) Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd);
         }
-    }
+    }    //TODO:ADD delay.
+
 
 }

--- a/src/main/java/think/rpgitems/power/PowerDeathCommand.java
+++ b/src/main/java/think/rpgitems/power/PowerDeathCommand.java
@@ -49,8 +49,7 @@ public class PowerDeathCommand extends Power implements PowerHit {
      */
     @Property
     public int consumption = 0;
-    //TODO:ADD delay.
-    //TODO:ADD delay.
+
 
     @Override
     public void init(ConfigurationSection s) {
@@ -58,7 +57,7 @@ public class PowerDeathCommand extends Power implements PowerHit {
         chance = s.getInt("chance");
         desc = s.getString("desc");
         count = s.getInt("count");
-        consumption = s.getInt("consumption", 0);    //    //TODO:ADD delay.
+        consumption = s.getInt("consumption", 0);
 
     }
 
@@ -69,7 +68,7 @@ public class PowerDeathCommand extends Power implements PowerHit {
         s.set("desc", desc);
         s.set("count", count);
         s.set("consumption", consumption);
-    }    //TODO:ADD delay.
+    }
 
 
     @Override
@@ -95,7 +94,6 @@ public class PowerDeathCommand extends Power implements PowerHit {
             String cmd = command.replace("${x}", String.valueOf(x)).replace("${y}", String.valueOf(y)).replace("${z}", String.valueOf(z));
             for (int i = 0; i < count; i++) Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd);
         }
-    }    //TODO:ADD delay.
-
+    }
 
 }

--- a/src/main/java/think/rpgitems/power/PowerDeflect.java
+++ b/src/main/java/think/rpgitems/power/PowerDeflect.java
@@ -103,6 +103,7 @@ public class PowerDeflect extends Power implements PowerHitTaken, PowerRightClic
     public double facing = 30;
 
     private long time = 0;
+    //TODO:ADD delay.
 
     @Override
     public String displayText() {
@@ -124,7 +125,8 @@ public class PowerDeflect extends Power implements PowerHitTaken, PowerRightClic
         facing = s.getInt("facing", 120);
         initiative = s.getBoolean("initiative", true);
         passive = s.getBoolean("passive", true);
-        isRight = s.getBoolean("isRight", true);
+        isRight = s.getBoolean("isRight", true);    //TODO:ADD delay.
+
     }
 
     @Override
@@ -138,7 +140,8 @@ public class PowerDeflect extends Power implements PowerHitTaken, PowerRightClic
         s.set("passive", passive);
         s.set("initiative", initiative);
         s.set("isRight", isRight);
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public double takeHit(Player target, ItemStack stack, EntityDamageEvent event) {
@@ -185,7 +188,8 @@ public class PowerDeflect extends Power implements PowerHitTaken, PowerRightClic
                     || !checkCooldownByString(player, item, "deflect.initiative", cooldownTime, true)
                     || !item.consumeDurability(stack, consumption))
             return;
-        time = System.currentTimeMillis() / 50 + duration;
+        time = System.currentTimeMillis() / 50 + duration;    //TODO:ADD delay.
+
     }
 
     @Override
@@ -195,6 +199,7 @@ public class PowerDeflect extends Power implements PowerHitTaken, PowerRightClic
                     || !checkCooldownByString(player, item, "deflect.initiative", cooldownTime, true)
                     || !item.consumeDurability(stack, consumption))
             return;
-        time = System.currentTimeMillis() / 50 + duration;
+        time = System.currentTimeMillis() / 50 + duration;    //TODO:ADD delay.
+
     }
 }

--- a/src/main/java/think/rpgitems/power/PowerDeflect.java
+++ b/src/main/java/think/rpgitems/power/PowerDeflect.java
@@ -103,7 +103,7 @@ public class PowerDeflect extends Power implements PowerHitTaken, PowerRightClic
     public double facing = 30;
 
     private long time = 0;
-    //TODO:ADD delay.
+
 
     @Override
     public String displayText() {
@@ -125,7 +125,7 @@ public class PowerDeflect extends Power implements PowerHitTaken, PowerRightClic
         facing = s.getInt("facing", 120);
         initiative = s.getBoolean("initiative", true);
         passive = s.getBoolean("passive", true);
-        isRight = s.getBoolean("isRight", true);    //TODO:ADD delay.
+        isRight = s.getBoolean("isRight", true);
 
     }
 
@@ -140,7 +140,7 @@ public class PowerDeflect extends Power implements PowerHitTaken, PowerRightClic
         s.set("passive", passive);
         s.set("initiative", initiative);
         s.set("isRight", isRight);
-    }    //TODO:ADD delay.
+        }
 
 
     @Override
@@ -188,7 +188,7 @@ public class PowerDeflect extends Power implements PowerHitTaken, PowerRightClic
                     || !checkCooldownByString(player, item, "deflect.initiative", cooldownTime, true)
                     || !item.consumeDurability(stack, consumption))
             return;
-        time = System.currentTimeMillis() / 50 + duration;    //TODO:ADD delay.
+        time = System.currentTimeMillis() / 50 + duration;
 
     }
 
@@ -199,7 +199,7 @@ public class PowerDeflect extends Power implements PowerHitTaken, PowerRightClic
                     || !checkCooldownByString(player, item, "deflect.initiative", cooldownTime, true)
                     || !item.consumeDurability(stack, consumption))
             return;
-        time = System.currentTimeMillis() / 50 + duration;    //TODO:ADD delay.
+        time = System.currentTimeMillis() / 50 + duration;
 
     }
 }

--- a/src/main/java/think/rpgitems/power/PowerDelayedCommand.java
+++ b/src/main/java/think/rpgitems/power/PowerDelayedCommand.java
@@ -15,6 +15,7 @@ import think.rpgitems.commands.Property;
  * giving the permission {@link #permission} just for the use of the command.
  * </p>
  */
+@Deprecated
 @SuppressWarnings("WeakerAccess")
 public class PowerDelayedCommand extends PowerCommand {
     /**

--- a/src/main/java/think/rpgitems/power/PowerFire.java
+++ b/src/main/java/think/rpgitems/power/PowerFire.java
@@ -70,6 +70,7 @@ public class PowerFire extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
 
     @Override
     public void rightClick(final Player player, ItemStack stack, Block clicked) {
@@ -152,7 +153,8 @@ public class PowerFire extends Power implements PowerRightClick {
             }
         };
         run.runTaskTimer(RPGItems.plugin, 0, 1);
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public String displayText() {
@@ -169,7 +171,9 @@ public class PowerFire extends Power implements PowerRightClick {
         cooldownTime = s.getLong("cooldown", 20);
         distance = s.getInt("distance");
         burnduration = s.getInt("burnduration");
-        consumption = s.getInt("consumption", 0);
+        consumption = s.getInt("consumption", 0);    //TODO:ADD delay.
+        //TODO:ADD delay.
+
     }
 
     @Override
@@ -178,6 +182,7 @@ public class PowerFire extends Power implements PowerRightClick {
         s.set("distance", distance);
         s.set("burnduration", burnduration);
         s.set("consumption", consumption);
-    }
+    }    //TODO:ADD delay.
+
 
 }

--- a/src/main/java/think/rpgitems/power/PowerFire.java
+++ b/src/main/java/think/rpgitems/power/PowerFire.java
@@ -73,7 +73,7 @@ public class PowerFire extends Power implements PowerRightClick {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 3)
     public int delay = 0;
 
     @Override

--- a/src/main/java/think/rpgitems/power/PowerFire.java
+++ b/src/main/java/think/rpgitems/power/PowerFire.java
@@ -70,7 +70,11 @@ public class PowerFire extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
 
     @Override
     public void rightClick(final Player player, ItemStack stack, Block clicked) {
@@ -152,8 +156,8 @@ public class PowerFire extends Power implements PowerRightClick {
                     cancel();
             }
         };
-        run.runTaskTimer(RPGItems.plugin, 0, 1);
-    }    //TODO:ADD delay.
+        run.runTaskTimer(RPGItems.plugin, delay, 1);
+    }
 
 
     @Override
@@ -171,8 +175,8 @@ public class PowerFire extends Power implements PowerRightClick {
         cooldownTime = s.getLong("cooldown", 20);
         distance = s.getInt("distance");
         burnduration = s.getInt("burnduration");
-        consumption = s.getInt("consumption", 0);    //TODO:ADD delay.
-        //TODO:ADD delay.
+        consumption = s.getInt("consumption", 0);
+        delay = s.getInt("delay");
 
     }
 
@@ -182,7 +186,8 @@ public class PowerFire extends Power implements PowerRightClick {
         s.set("distance", distance);
         s.set("burnduration", burnduration);
         s.set("consumption", consumption);
-    }    //TODO:ADD delay.
+        s.set("delay",delay);
+    }
 
 
 }

--- a/src/main/java/think/rpgitems/power/PowerFireball.java
+++ b/src/main/java/think/rpgitems/power/PowerFireball.java
@@ -45,6 +45,7 @@ public class PowerFireball extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
 
     @Override
     public void rightClick(Player player, ItemStack stack, Block clicked) {
@@ -68,13 +69,17 @@ public class PowerFireball extends Power implements PowerRightClick {
     @Override
     public void init(ConfigurationSection s) {
         cooldownTime = s.getLong("cooldown", 20);
-        consumption = s.getInt("consumption", 1);
+        consumption = s.getInt("consumption", 1);    //TODO:ADD delay.
+        //TODO:ADD delay.
+
     }
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("cooldown", cooldownTime);
-        s.set("consumption", consumption);
+        s.set("consumption", consumption);    //TODO:ADD delay.
+        //TODO:ADD delay.
+
     }
 
 }

--- a/src/main/java/think/rpgitems/power/PowerFireball.java
+++ b/src/main/java/think/rpgitems/power/PowerFireball.java
@@ -45,7 +45,11 @@ public class PowerFireball extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
 
     @Override
     public void rightClick(Player player, ItemStack stack, Block clicked) {
@@ -69,16 +73,16 @@ public class PowerFireball extends Power implements PowerRightClick {
     @Override
     public void init(ConfigurationSection s) {
         cooldownTime = s.getLong("cooldown", 20);
-        consumption = s.getInt("consumption", 1);    //TODO:ADD delay.
-        //TODO:ADD delay.
+        consumption = s.getInt("consumption", 1);
+        delay = s.getInt("delay");
 
     }
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("cooldown", cooldownTime);
-        s.set("consumption", consumption);    //TODO:ADD delay.
-        //TODO:ADD delay.
+        s.set("consumption", consumption);
+        s.set("delay",delay);
 
     }
 

--- a/src/main/java/think/rpgitems/power/PowerFireball.java
+++ b/src/main/java/think/rpgitems/power/PowerFireball.java
@@ -48,7 +48,7 @@ public class PowerFireball extends Power implements PowerRightClick {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 1)
     public int delay = 0;
 
     @Override

--- a/src/main/java/think/rpgitems/power/PowerFlame.java
+++ b/src/main/java/think/rpgitems/power/PowerFlame.java
@@ -20,7 +20,9 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
 import think.rpgitems.I18n;
+import think.rpgitems.RPGItems;
 import think.rpgitems.commands.Property;
 import think.rpgitems.power.types.PowerHit;
 
@@ -43,13 +45,22 @@ public class PowerFlame extends Power implements PowerHit {
      */
     @Property
     public int consumption = 0;
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
 
     @Override
     public void hit(Player player, ItemStack stack, LivingEntity entity, double damage) {
         if (!item.checkPermission(player, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
-        entity.setFireTicks(burnTime);
+        new BukkitRunnable(){
+            @Override
+            public void run() {
+                entity.setFireTicks(burnTime);
+            }
+        }.runTaskLater(RPGItems.plugin,delay);
     }
 
     @Override
@@ -65,8 +76,8 @@ public class PowerFlame extends Power implements PowerHit {
     @Override
     public void init(ConfigurationSection s) {
         burnTime = s.getInt("burntime");
-        consumption = s.getInt("consumption", 0);    //TODO:ADD delay.
-        //TODO:ADD delay.
+        consumption = s.getInt("consumption", 0);
+        delay = s.getInt("delay");
 
     }
 
@@ -74,7 +85,8 @@ public class PowerFlame extends Power implements PowerHit {
     public void save(ConfigurationSection s) {
         s.set("burntime", burnTime);
         s.set("consumption", consumption);
-    }    //TODO:ADD delay.
+        s.set("delay",delay);
+    }
 
 
 }

--- a/src/main/java/think/rpgitems/power/PowerFlame.java
+++ b/src/main/java/think/rpgitems/power/PowerFlame.java
@@ -43,6 +43,7 @@ public class PowerFlame extends Power implements PowerHit {
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
 
     @Override
     public void hit(Player player, ItemStack stack, LivingEntity entity, double damage) {
@@ -64,13 +65,16 @@ public class PowerFlame extends Power implements PowerHit {
     @Override
     public void init(ConfigurationSection s) {
         burnTime = s.getInt("burntime");
-        consumption = s.getInt("consumption", 0);
+        consumption = s.getInt("consumption", 0);    //TODO:ADD delay.
+        //TODO:ADD delay.
+
     }
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("burntime", burnTime);
         s.set("consumption", consumption);
-    }
+    }    //TODO:ADD delay.
+
 
 }

--- a/src/main/java/think/rpgitems/power/PowerFlame.java
+++ b/src/main/java/think/rpgitems/power/PowerFlame.java
@@ -48,7 +48,7 @@ public class PowerFlame extends Power implements PowerHit {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 1)
     public int delay = 0;
 
     @Override

--- a/src/main/java/think/rpgitems/power/PowerFood.java
+++ b/src/main/java/think/rpgitems/power/PowerFood.java
@@ -40,6 +40,8 @@ public class PowerFood extends Power implements PowerRightClick {
      */
     @Property(order = 0, required = true)
     public int foodpoints;
+    //TODO:ADD delay.
+    //TODO:ADD delay.
 
     @Override
     public void rightClick(final Player player, ItemStack stack, Block clicked) {
@@ -64,11 +66,13 @@ public class PowerFood extends Power implements PowerRightClick {
 
     @Override
     public void init(ConfigurationSection s) {
-        foodpoints = s.getInt("foodpoints");
+        foodpoints = s.getInt("foodpoints");    //TODO:ADD delay.
+
     }
 
     @Override
-    public void save(ConfigurationSection s) {
+    public void save(ConfigurationSection s) {    //TODO:ADD delay.
+
         s.set("foodpoints", foodpoints);
     }
 

--- a/src/main/java/think/rpgitems/power/PowerFood.java
+++ b/src/main/java/think/rpgitems/power/PowerFood.java
@@ -45,7 +45,7 @@ public class PowerFood extends Power implements PowerRightClick {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 1)
     public int delay = 0;
 
     @Override

--- a/src/main/java/think/rpgitems/power/PowerFood.java
+++ b/src/main/java/think/rpgitems/power/PowerFood.java
@@ -22,9 +22,11 @@ import org.bukkit.block.Block;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
 import think.rpgitems.I18n;
 import think.rpgitems.RPGItems;
 import think.rpgitems.commands.Property;
+import think.rpgitems.item.RPGItem;
 import think.rpgitems.power.types.PowerRightClick;
 
 /**
@@ -40,40 +42,47 @@ public class PowerFood extends Power implements PowerRightClick {
      */
     @Property(order = 0, required = true)
     public int foodpoints;
-    //TODO:ADD delay.
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
 
     @Override
     public void rightClick(final Player player, ItemStack stack, Block clicked) {
         if (!item.checkPermission(player, true)) return;
-        ItemStack item = player.getInventory().getItemInMainHand();
-        int count = item.getAmount() - 1;
-        if (count == 0) {
-            int newFoodPoint = player.getFoodLevel() + foodpoints;
-            if (newFoodPoint > 20) newFoodPoint = 20;
-            player.setFoodLevel(newFoodPoint);
-            Bukkit.getScheduler().scheduleSyncDelayedTask(RPGItems.plugin, new Runnable() {
-                @Override
-                public void run() {
-                    player.getInventory().setItemInMainHand(new ItemStack(Material.AIR));
+        new BukkitRunnable(){
+            @Override
+            public void run() {
+                ItemStack item = player.getInventory().getItemInMainHand();
+                int count = item.getAmount() - 1;
+                if (count == 0) {
+                    int newFoodPoint = player.getFoodLevel() + foodpoints;
+                    if (newFoodPoint > 20) newFoodPoint = 20;
+                    player.setFoodLevel(newFoodPoint);
+                    Bukkit.getScheduler().scheduleSyncDelayedTask(RPGItems.plugin, new Runnable() {
+                        @Override
+                        public void run() {
+                            player.getInventory().setItemInMainHand(new ItemStack(Material.AIR));
+                        }
+                    }, 1L);
+                } else {
+                    player.setFoodLevel(player.getFoodLevel() + foodpoints);
+                    item.setAmount(count);
                 }
-            }, 1L);
-        } else {
-            player.setFoodLevel(player.getFoodLevel() + foodpoints);
-            item.setAmount(count);
-        }
+            }
+        }.runTaskLater(RPGItems.plugin,delay);
     }
-
     @Override
     public void init(ConfigurationSection s) {
-        foodpoints = s.getInt("foodpoints");    //TODO:ADD delay.
-
+        foodpoints = s.getInt("foodpoints");
+        delay = s.getInt("delay");
     }
 
     @Override
-    public void save(ConfigurationSection s) {    //TODO:ADD delay.
-
+    public void save(ConfigurationSection s) {
         s.set("foodpoints", foodpoints);
+        s.set("delay",delay);
     }
 
     @Override

--- a/src/main/java/think/rpgitems/power/PowerForceField.java
+++ b/src/main/java/think/rpgitems/power/PowerForceField.java
@@ -59,7 +59,11 @@ public class PowerForceField extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
 
     @Override
     public void init(ConfigurationSection s) {
@@ -69,7 +73,8 @@ public class PowerForceField extends Power implements PowerRightClick {
         base = s.getInt("base");
         ttl = s.getInt("ttl");
         consumption = s.getInt("consumption", 0);
-    }    //TODO:ADD delay.
+        delay = s.getInt("delay",0);
+    }
 
 
     @Override
@@ -79,8 +84,8 @@ public class PowerForceField extends Power implements PowerRightClick {
         s.set("height", height);
         s.set("base", base);
         s.set("ttl", ttl);
-        s.set("consumption", consumption);    //TODO:ADD delay.
-
+        s.set("consumption", consumption);
+        s.set("delay",delay);
     }
 
     @Override
@@ -94,11 +99,12 @@ public class PowerForceField extends Power implements PowerRightClick {
     }
 
     @Override
-    public void rightClick(Player player, ItemStack stack, Block clicked) {    //TODO:ADD delay.
+    public void rightClick(Player player, ItemStack stack, Block clicked) {
 
         if (!item.checkPermission(player, true)) return;
         if (!checkCooldown(player, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
+
         World w = player.getWorld();
         int x = player.getLocation().getBlockX();
         int y = player.getLocation().getBlockY();
@@ -111,7 +117,7 @@ public class PowerForceField extends Power implements PowerRightClick {
         if (h < 1) return;
 
         buildWallTask tsk = new buildWallTask(w, circlePoints(w, x, z, radius, l), l, h, ttl);
-        tsk.setId(Bukkit.getScheduler().scheduleSyncRepeatingTask(RPGItems.plugin, tsk, 1, 1));
+        tsk.setId(Bukkit.getScheduler().scheduleSyncRepeatingTask(RPGItems.plugin, tsk, delay, 1));
     }
 
     /* copied from wikipedia */

--- a/src/main/java/think/rpgitems/power/PowerForceField.java
+++ b/src/main/java/think/rpgitems/power/PowerForceField.java
@@ -62,7 +62,7 @@ public class PowerForceField extends Power implements PowerRightClick {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 5)
     public int delay = 0;
 
     @Override

--- a/src/main/java/think/rpgitems/power/PowerForceField.java
+++ b/src/main/java/think/rpgitems/power/PowerForceField.java
@@ -59,6 +59,7 @@ public class PowerForceField extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
 
     @Override
     public void init(ConfigurationSection s) {
@@ -68,7 +69,8 @@ public class PowerForceField extends Power implements PowerRightClick {
         base = s.getInt("base");
         ttl = s.getInt("ttl");
         consumption = s.getInt("consumption", 0);
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public void save(ConfigurationSection s) {
@@ -77,7 +79,8 @@ public class PowerForceField extends Power implements PowerRightClick {
         s.set("height", height);
         s.set("base", base);
         s.set("ttl", ttl);
-        s.set("consumption", consumption);
+        s.set("consumption", consumption);    //TODO:ADD delay.
+
     }
 
     @Override
@@ -91,7 +94,8 @@ public class PowerForceField extends Power implements PowerRightClick {
     }
 
     @Override
-    public void rightClick(Player player, ItemStack stack, Block clicked) {
+    public void rightClick(Player player, ItemStack stack, Block clicked) {    //TODO:ADD delay.
+
         if (!item.checkPermission(player, true)) return;
         if (!checkCooldown(player, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;

--- a/src/main/java/think/rpgitems/power/PowerIce.java
+++ b/src/main/java/think/rpgitems/power/PowerIce.java
@@ -53,6 +53,7 @@ public class PowerIce extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
 
     @SuppressWarnings("deprecation")
     @Override
@@ -134,7 +135,8 @@ public class PowerIce extends Power implements PowerRightClick {
             }
         };
         run.runTaskTimer(RPGItems.plugin, 0, 1);
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public String displayText() {
@@ -150,12 +152,15 @@ public class PowerIce extends Power implements PowerRightClick {
     public void init(ConfigurationSection s) {
         cooldownTime = s.getLong("cooldown", 20);
         consumption = s.getInt("consumption", 0);
-    }
+    }    //TODO:ADD delay.
+    //TODO:ADD delay.
+
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("cooldown", cooldownTime);
         s.set("consumption", consumption);
-    }
+    }    //TODO:ADD delay.
+
 
 }

--- a/src/main/java/think/rpgitems/power/PowerIce.java
+++ b/src/main/java/think/rpgitems/power/PowerIce.java
@@ -53,7 +53,11 @@ public class PowerIce extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
 
     @SuppressWarnings("deprecation")
     @Override
@@ -134,8 +138,8 @@ public class PowerIce extends Power implements PowerRightClick {
 
             }
         };
-        run.runTaskTimer(RPGItems.plugin, 0, 1);
-    }    //TODO:ADD delay.
+        run.runTaskTimer(RPGItems.plugin, delay, 1);
+    }
 
 
     @Override
@@ -152,15 +156,16 @@ public class PowerIce extends Power implements PowerRightClick {
     public void init(ConfigurationSection s) {
         cooldownTime = s.getLong("cooldown", 20);
         consumption = s.getInt("consumption", 0);
-    }    //TODO:ADD delay.
-    //TODO:ADD delay.
+        delay = s.getInt("delay");
+    }
 
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("cooldown", cooldownTime);
         s.set("consumption", consumption);
-    }    //TODO:ADD delay.
+        s.set("delay",delay);
+    }
 
 
 }

--- a/src/main/java/think/rpgitems/power/PowerIce.java
+++ b/src/main/java/think/rpgitems/power/PowerIce.java
@@ -56,7 +56,7 @@ public class PowerIce extends Power implements PowerRightClick {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 1)
     public int delay = 0;
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/think/rpgitems/power/PowerKnockup.java
+++ b/src/main/java/think/rpgitems/power/PowerKnockup.java
@@ -50,6 +50,7 @@ public class PowerKnockup extends Power implements PowerHit {
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
 
     private Random rand = new Random();
 
@@ -60,7 +61,8 @@ public class PowerKnockup extends Power implements PowerHit {
         if (rand.nextInt(chance) == 0) {
             entity.setVelocity(player.getLocation().getDirection().setY(power));
         }
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public String displayText() {
@@ -78,12 +80,13 @@ public class PowerKnockup extends Power implements PowerHit {
         power = s.getDouble("power", 2);
         consumption = s.getInt("consumption", 0);
     }
-
+    //TODO:ADD delay.
     @Override
     public void save(ConfigurationSection s) {
         s.set("chance", chance);
         s.set("power", power);
         s.set("consumption", consumption);
     }
+    //TODO:ADD delay.
 
 }

--- a/src/main/java/think/rpgitems/power/PowerKnockup.java
+++ b/src/main/java/think/rpgitems/power/PowerKnockup.java
@@ -20,7 +20,9 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
 import think.rpgitems.I18n;
+import think.rpgitems.RPGItems;
 import think.rpgitems.commands.Property;
 import think.rpgitems.power.types.PowerHit;
 
@@ -50,7 +52,11 @@ public class PowerKnockup extends Power implements PowerHit {
      */
     @Property
     public int consumption = 0;
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
 
     private Random rand = new Random();
 
@@ -59,9 +65,14 @@ public class PowerKnockup extends Power implements PowerHit {
         if (!item.checkPermission(player, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
         if (rand.nextInt(chance) == 0) {
-            entity.setVelocity(player.getLocation().getDirection().setY(power));
+            new BukkitRunnable(){
+                @Override
+                public void run() {
+                    entity.setVelocity(player.getLocation().getDirection().setY(power));
+                }
+            }.runTaskLater(RPGItems.plugin,delay);
         }
-    }    //TODO:ADD delay.
+    }
 
 
     @Override
@@ -79,14 +90,14 @@ public class PowerKnockup extends Power implements PowerHit {
         chance = s.getInt("chance");
         power = s.getDouble("power", 2);
         consumption = s.getInt("consumption", 0);
+        delay = s.getInt("delay");
     }
-    //TODO:ADD delay.
     @Override
     public void save(ConfigurationSection s) {
         s.set("chance", chance);
         s.set("power", power);
         s.set("consumption", consumption);
+        s.set("delay",delay);
     }
-    //TODO:ADD delay.
 
 }

--- a/src/main/java/think/rpgitems/power/PowerKnockup.java
+++ b/src/main/java/think/rpgitems/power/PowerKnockup.java
@@ -55,7 +55,7 @@ public class PowerKnockup extends Power implements PowerHit {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 2)
     public int delay = 0;
 
     private Random rand = new Random();

--- a/src/main/java/think/rpgitems/power/PowerLifeSteal.java
+++ b/src/main/java/think/rpgitems/power/PowerLifeSteal.java
@@ -48,6 +48,7 @@ public class PowerLifeSteal extends Power implements PowerHit {
     public int consumption = 0;
 
     private Random random = new Random();
+    //TODO:ADD delay.
 
     @Override
     public void hit(Player player, ItemStack stack, LivingEntity entity, double damage) {
@@ -75,12 +76,14 @@ public class PowerLifeSteal extends Power implements PowerHit {
     public void init(ConfigurationSection s) {
         chance = s.getInt("chance");
         consumption = s.getInt("consumption", 0);
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("chance", chance);
         s.set("consumption", consumption);
     }
+    //TODO:ADD delay.
 
 }

--- a/src/main/java/think/rpgitems/power/PowerLifeSteal.java
+++ b/src/main/java/think/rpgitems/power/PowerLifeSteal.java
@@ -54,7 +54,7 @@ public class PowerLifeSteal extends Power implements PowerHit {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 1)
     public int delay = 0;
 
     @Override

--- a/src/main/java/think/rpgitems/power/PowerLifeSteal.java
+++ b/src/main/java/think/rpgitems/power/PowerLifeSteal.java
@@ -21,8 +21,11 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
 import think.rpgitems.I18n;
+import think.rpgitems.RPGItems;
 import think.rpgitems.commands.Property;
+import think.rpgitems.item.RPGItem;
 import think.rpgitems.power.types.PowerHit;
 
 import java.util.Random;
@@ -48,17 +51,26 @@ public class PowerLifeSteal extends Power implements PowerHit {
     public int consumption = 0;
 
     private Random random = new Random();
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
 
     @Override
     public void hit(Player player, ItemStack stack, LivingEntity entity, double damage) {
         if (!item.checkPermission(player, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
         if (random.nextInt(chance) == 0) {
-            if ((player.getHealth() + damage) >= player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue()) {
-                player.setHealth(player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue());
-            } else
-                player.setHealth(player.getHealth() + damage);
+            new BukkitRunnable(){
+                @Override
+                public void run() {
+                    if ((player.getHealth() + damage) >= player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue()) {
+                        player.setHealth(player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue());
+                    } else
+                        player.setHealth(player.getHealth() + damage);
+                }
+            }.runTaskLater(RPGItems.plugin,delay);
         }
     }
 
@@ -76,14 +88,15 @@ public class PowerLifeSteal extends Power implements PowerHit {
     public void init(ConfigurationSection s) {
         chance = s.getInt("chance");
         consumption = s.getInt("consumption", 0);
-    }    //TODO:ADD delay.
+        delay = s.getInt("delay",0);
+    }
 
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("chance", chance);
         s.set("consumption", consumption);
+        s.set("delay",delay);
     }
-    //TODO:ADD delay.
 
 }

--- a/src/main/java/think/rpgitems/power/PowerLightning.java
+++ b/src/main/java/think/rpgitems/power/PowerLightning.java
@@ -52,7 +52,7 @@ public class PowerLightning extends Power implements PowerHit, PowerProjectileHi
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 1)
     public int delay = 0;
 
     @Override

--- a/src/main/java/think/rpgitems/power/PowerLightning.java
+++ b/src/main/java/think/rpgitems/power/PowerLightning.java
@@ -47,6 +47,7 @@ public class PowerLightning extends Power implements PowerHit, PowerProjectileHi
     public int consumption = 0;
 
     private Random random = new Random();
+    //TODO:ADD delay.
 
     @Override
     public void hit(Player player, ItemStack stack, LivingEntity entity, double damage) {
@@ -56,6 +57,7 @@ public class PowerLightning extends Power implements PowerHit, PowerProjectileHi
             entity.getWorld().strikeLightning(entity.getLocation());
         }
     }
+    //TODO:ADD delay.
 
     @Override
     public void projectileHit(Player player, ItemStack stack, Projectile p) {
@@ -80,12 +82,14 @@ public class PowerLightning extends Power implements PowerHit, PowerProjectileHi
     public void init(ConfigurationSection s) {
         chance = s.getInt("chance");
         consumption = s.getInt("consumption", 0);
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("chance", chance);
         s.set("consumption", consumption);
     }
+    //TODO:ADD delay.
 
 }

--- a/src/main/java/think/rpgitems/power/PowerLightning.java
+++ b/src/main/java/think/rpgitems/power/PowerLightning.java
@@ -21,7 +21,9 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
 import think.rpgitems.I18n;
+import think.rpgitems.RPGItems;
 import think.rpgitems.commands.Property;
 import think.rpgitems.power.types.PowerHit;
 import think.rpgitems.power.types.PowerProjectileHit;
@@ -47,17 +49,25 @@ public class PowerLightning extends Power implements PowerHit, PowerProjectileHi
     public int consumption = 0;
 
     private Random random = new Random();
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
 
     @Override
     public void hit(Player player, ItemStack stack, LivingEntity entity, double damage) {
         if (!item.checkPermission(player, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
         if (random.nextInt(chance) == 0) {
-            entity.getWorld().strikeLightning(entity.getLocation());
+            new BukkitRunnable(){
+                @Override
+                public void run() {
+                    entity.getWorld().strikeLightning(entity.getLocation());
+                }
+            }.runTaskLater(RPGItems.plugin,delay);
         }
     }
-    //TODO:ADD delay.
 
     @Override
     public void projectileHit(Player player, ItemStack stack, Projectile p) {
@@ -82,14 +92,14 @@ public class PowerLightning extends Power implements PowerHit, PowerProjectileHi
     public void init(ConfigurationSection s) {
         chance = s.getInt("chance");
         consumption = s.getInt("consumption", 0);
-    }    //TODO:ADD delay.
-
+        delay = s.getInt("delay",0);
+    }
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("chance", chance);
         s.set("consumption", consumption);
+        s.set("delay",delay);
     }
-    //TODO:ADD delay.
 
 }

--- a/src/main/java/think/rpgitems/power/PowerLoreFilter.java
+++ b/src/main/java/think/rpgitems/power/PowerLoreFilter.java
@@ -22,18 +22,21 @@ public class PowerLoreFilter extends Power {
      */
     @Property(order = 1, required = true)
     public String desc = "";
+    //TODO:ADD delay.
 
     @Override
     public void init(ConfigurationSection s) {
         regex = s.getString("regex", null);
         desc = s.getString("desc", "");
     }
+    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("regex", regex);
         s.set("desc", desc);
     }
+    //TODO:ADD delay.
 
     @Override
     public String getName() {

--- a/src/main/java/think/rpgitems/power/PowerLoreFilter.java
+++ b/src/main/java/think/rpgitems/power/PowerLoreFilter.java
@@ -22,21 +22,20 @@ public class PowerLoreFilter extends Power {
      */
     @Property(order = 1, required = true)
     public String desc = "";
-    //TODO:ADD delay.
 
     @Override
     public void init(ConfigurationSection s) {
         regex = s.getString("regex", null);
         desc = s.getString("desc", "");
     }
-    //TODO:ADD delay.
+
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("regex", regex);
         s.set("desc", desc);
     }
-    //TODO:ADD delay.
+
 
     @Override
     public String getName() {

--- a/src/main/java/think/rpgitems/power/PowerNoImmutableTick.java
+++ b/src/main/java/think/rpgitems/power/PowerNoImmutableTick.java
@@ -16,6 +16,7 @@ public class PowerNoImmutableTick extends Power implements PowerHit {
 
     }
 
+
     @Override
     public void save(ConfigurationSection s) {
 

--- a/src/main/java/think/rpgitems/power/PowerParticle.java
+++ b/src/main/java/think/rpgitems/power/PowerParticle.java
@@ -33,7 +33,7 @@ public class PowerParticle extends Power implements PowerRightClick {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 1)
     public int delay = 0;
 
     /**

--- a/src/main/java/think/rpgitems/power/PowerParticle.java
+++ b/src/main/java/think/rpgitems/power/PowerParticle.java
@@ -28,6 +28,7 @@ public class PowerParticle extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
 
     /**
      * Acceptable effect boolean.
@@ -48,13 +49,15 @@ public class PowerParticle extends Power implements PowerRightClick {
     public void init(ConfigurationSection s) {
         effect = s.getString("effect", "FLAME");
         consumption = s.getInt("consumption", 0);
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("effect", effect);
         s.set("consumption", consumption);
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public String getName() {
@@ -74,6 +77,7 @@ public class PowerParticle extends Power implements PowerRightClick {
         } else {
             player.getWorld().playEffect(player.getLocation(), Effect.valueOf(effect), 0);
         }
-    }
+    }    //TODO:ADD delay.
+
 
 }

--- a/src/main/java/think/rpgitems/power/PowerParticle.java
+++ b/src/main/java/think/rpgitems/power/PowerParticle.java
@@ -5,7 +5,9 @@ import org.bukkit.block.Block;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
 import think.rpgitems.I18n;
+import think.rpgitems.RPGItems;
 import think.rpgitems.commands.Property;
 import think.rpgitems.commands.Validator;
 import think.rpgitems.power.types.PowerRightClick;
@@ -28,7 +30,11 @@ public class PowerParticle extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
 
     /**
      * Acceptable effect boolean.
@@ -49,14 +55,16 @@ public class PowerParticle extends Power implements PowerRightClick {
     public void init(ConfigurationSection s) {
         effect = s.getString("effect", "FLAME");
         consumption = s.getInt("consumption", 0);
-    }    //TODO:ADD delay.
+        delay = s.getInt("delay",0);
+    }
 
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("effect", effect);
         s.set("consumption", consumption);
-    }    //TODO:ADD delay.
+        s.set("delay",delay);
+    }
 
 
     @Override
@@ -73,11 +81,21 @@ public class PowerParticle extends Power implements PowerRightClick {
     public void rightClick(Player player, ItemStack stack, Block clicked) {
         if (!item.consumeDurability(stack, consumption)) return;
         if (effect.equalsIgnoreCase("SMOKE")) {
-            player.getWorld().playEffect(player.getLocation().add(0, 2, 0), Effect.valueOf(effect), 4);
+            new BukkitRunnable(){
+                @Override
+                public void run() {
+                    player.getWorld().playEffect(player.getLocation().add(0, 2, 0), Effect.valueOf(effect), 4);
+                }
+            }.runTaskLater(RPGItems.plugin,delay);
         } else {
-            player.getWorld().playEffect(player.getLocation(), Effect.valueOf(effect), 0);
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    player.getWorld().playEffect(player.getLocation(), Effect.valueOf(effect), 0);
+                }
+            }.runTaskLater(RPGItems.plugin, delay);
         }
-    }    //TODO:ADD delay.
+    }
 
 
 }

--- a/src/main/java/think/rpgitems/power/PowerParticleTick.java
+++ b/src/main/java/think/rpgitems/power/PowerParticleTick.java
@@ -34,7 +34,6 @@ public class PowerParticleTick extends Power implements PowerTick {
      */
     @Property
     public int consumption = 0;
-    //TODO:ADD delay.
 
     /**
      * Acceptable effect boolean.
@@ -57,7 +56,6 @@ public class PowerParticleTick extends Power implements PowerTick {
         interval = s.getInt("interval");
         consumption = s.getInt("consumption", 0);
     }
-    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
@@ -65,7 +63,6 @@ public class PowerParticleTick extends Power implements PowerTick {
         s.set("interval", interval);
         s.set("consumption", consumption);
     }
-    //TODO:ADD delay.
 
     @Override
     public String getName() {
@@ -86,6 +83,6 @@ public class PowerParticleTick extends Power implements PowerTick {
         } else {
             player.getWorld().playEffect(player.getLocation(), Effect.valueOf(effect), 0);
         }
-    }    //TODO:ADD delay.
+    }
 
 }

--- a/src/main/java/think/rpgitems/power/PowerParticleTick.java
+++ b/src/main/java/think/rpgitems/power/PowerParticleTick.java
@@ -34,6 +34,7 @@ public class PowerParticleTick extends Power implements PowerTick {
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
 
     /**
      * Acceptable effect boolean.
@@ -56,6 +57,7 @@ public class PowerParticleTick extends Power implements PowerTick {
         interval = s.getInt("interval");
         consumption = s.getInt("consumption", 0);
     }
+    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
@@ -63,6 +65,7 @@ public class PowerParticleTick extends Power implements PowerTick {
         s.set("interval", interval);
         s.set("consumption", consumption);
     }
+    //TODO:ADD delay.
 
     @Override
     public String getName() {
@@ -83,5 +86,6 @@ public class PowerParticleTick extends Power implements PowerTick {
         } else {
             player.getWorld().playEffect(player.getLocation(), Effect.valueOf(effect), 0);
         }
-    }
+    }    //TODO:ADD delay.
+
 }

--- a/src/main/java/think/rpgitems/power/PowerPotionHit.java
+++ b/src/main/java/think/rpgitems/power/PowerPotionHit.java
@@ -69,7 +69,7 @@ public class PowerPotionHit extends Power implements PowerHit {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 3)
     public int delay = 0;
 
     private Random rand = new Random();

--- a/src/main/java/think/rpgitems/power/PowerPotionHit.java
+++ b/src/main/java/think/rpgitems/power/PowerPotionHit.java
@@ -64,6 +64,7 @@ public class PowerPotionHit extends Power implements PowerHit {
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
 
     private Random rand = new Random();
 
@@ -75,6 +76,7 @@ public class PowerPotionHit extends Power implements PowerHit {
             entity.addPotionEffect(new PotionEffect(type, duration, amplifier));
         }
     }
+    //TODO:ADD delay.
 
     @Override
     public String displayText() {
@@ -93,7 +95,8 @@ public class PowerPotionHit extends Power implements PowerHit {
         amplifier = s.getInt("amplifier", 1);
         type = PotionEffectType.getByName(s.getString("type", PotionEffectType.HARM.getName()));
         consumption = s.getInt("consumption", 0);
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public void save(ConfigurationSection s) {
@@ -102,7 +105,8 @@ public class PowerPotionHit extends Power implements PowerHit {
         s.set("amplifier", amplifier);
         s.set("type", type.getName());
         s.set("consumption", consumption);
-    }
+    }    //TODO:ADD delay.
+
 
     public void setType(String effect) {
         type = PotionEffectType.getByName(effect);

--- a/src/main/java/think/rpgitems/power/PowerPotionHit.java
+++ b/src/main/java/think/rpgitems/power/PowerPotionHit.java
@@ -22,7 +22,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitRunnable;
 import think.rpgitems.I18n;
+import think.rpgitems.RPGItems;
 import think.rpgitems.commands.Property;
 import think.rpgitems.commands.Setter;
 import think.rpgitems.power.types.PowerHit;
@@ -64,7 +66,11 @@ public class PowerPotionHit extends Power implements PowerHit {
      */
     @Property
     public int consumption = 0;
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
 
     private Random rand = new Random();
 
@@ -73,10 +79,14 @@ public class PowerPotionHit extends Power implements PowerHit {
         if (!item.checkPermission(player, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
         if (rand.nextInt(chance) == 0) {
-            entity.addPotionEffect(new PotionEffect(type, duration, amplifier));
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    entity.addPotionEffect(new PotionEffect(type, duration, amplifier));
+                }
+            }.runTaskLater(RPGItems.plugin,delay);
         }
     }
-    //TODO:ADD delay.
 
     @Override
     public String displayText() {
@@ -95,7 +105,8 @@ public class PowerPotionHit extends Power implements PowerHit {
         amplifier = s.getInt("amplifier", 1);
         type = PotionEffectType.getByName(s.getString("type", PotionEffectType.HARM.getName()));
         consumption = s.getInt("consumption", 0);
-    }    //TODO:ADD delay.
+        delay = s.getInt("delay", 0);
+    }
 
 
     @Override
@@ -105,7 +116,8 @@ public class PowerPotionHit extends Power implements PowerHit {
         s.set("amplifier", amplifier);
         s.set("type", type.getName());
         s.set("consumption", consumption);
-    }    //TODO:ADD delay.
+        s.set("delay",delay);
+    }
 
 
     public void setType(String effect) {

--- a/src/main/java/think/rpgitems/power/PowerPotionSelf.java
+++ b/src/main/java/think/rpgitems/power/PowerPotionSelf.java
@@ -62,7 +62,7 @@ public class PowerPotionSelf extends Power implements PowerRightClick {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 3)
     public int delay = 0;
 
     /**

--- a/src/main/java/think/rpgitems/power/PowerPotionSelf.java
+++ b/src/main/java/think/rpgitems/power/PowerPotionSelf.java
@@ -22,7 +22,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitRunnable;
 import think.rpgitems.I18n;
+import think.rpgitems.RPGItems;
 import think.rpgitems.commands.Property;
 import think.rpgitems.commands.Setter;
 import think.rpgitems.power.types.PowerRightClick;
@@ -58,8 +60,14 @@ public class PowerPotionSelf extends Power implements PowerRightClick {
     @Property
     public int consumption = 0;
     /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
+
+    /**
      * Type of potion effect
-     */    //TODO:ADD delay.
+     */
 
     @Setter("setType")
     @Property(order = 3, required = true)
@@ -70,8 +78,13 @@ public class PowerPotionSelf extends Power implements PowerRightClick {
         if (!item.checkPermission(player, true)) return;
         if (!checkCooldown(player, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
-        player.addPotionEffect(new PotionEffect(type, duration, amplifier), true);
-    }    //TODO:ADD delay.
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                player.addPotionEffect(new PotionEffect(type, duration, amplifier), true);
+            }
+        }.runTaskLater(RPGItems.plugin,delay);
+    }
 
 
     @Override
@@ -81,8 +94,8 @@ public class PowerPotionSelf extends Power implements PowerRightClick {
         duration = s.getInt("time");
         type = PotionEffectType.getByName(s.getString("type", "heal"));
         consumption = s.getInt("consumption", 0);
+        delay = s.getInt("delay",0);
     }
-    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
@@ -91,9 +104,8 @@ public class PowerPotionSelf extends Power implements PowerRightClick {
         s.set("time", duration);
         s.set("type", type.getName());
         s.set("consumption", consumption);
+        s.set("delay",delay);
     }
-    //TODO:ADD delay.
-
     @Override
     public String getName() {
         return "potionself";

--- a/src/main/java/think/rpgitems/power/PowerPotionSelf.java
+++ b/src/main/java/think/rpgitems/power/PowerPotionSelf.java
@@ -59,7 +59,8 @@ public class PowerPotionSelf extends Power implements PowerRightClick {
     public int consumption = 0;
     /**
      * Type of potion effect
-     */
+     */    //TODO:ADD delay.
+
     @Setter("setType")
     @Property(order = 3, required = true)
     public PotionEffectType type = PotionEffectType.HEAL;
@@ -70,7 +71,8 @@ public class PowerPotionSelf extends Power implements PowerRightClick {
         if (!checkCooldown(player, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
         player.addPotionEffect(new PotionEffect(type, duration, amplifier), true);
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public void init(ConfigurationSection s) {
@@ -80,6 +82,7 @@ public class PowerPotionSelf extends Power implements PowerRightClick {
         type = PotionEffectType.getByName(s.getString("type", "heal"));
         consumption = s.getInt("consumption", 0);
     }
+    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
@@ -89,6 +92,7 @@ public class PowerPotionSelf extends Power implements PowerRightClick {
         s.set("type", type.getName());
         s.set("consumption", consumption);
     }
+    //TODO:ADD delay.
 
     @Override
     public String getName() {

--- a/src/main/java/think/rpgitems/power/PowerProjectile.java
+++ b/src/main/java/think/rpgitems/power/PowerProjectile.java
@@ -91,7 +91,7 @@ public class PowerProjectile extends Power implements PowerRightClick {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 6)
     public int delay = 0;
 
 

--- a/src/main/java/think/rpgitems/power/PowerProjectile.java
+++ b/src/main/java/think/rpgitems/power/PowerProjectile.java
@@ -90,7 +90,8 @@ public class PowerProjectile extends Power implements PowerRightClick {
     public int burstInterval = 1;
     /**
      * Type of projectiles
-     */
+     */    //TODO:ADD delay.
+
     @AcceptedValue({
                            "skull",
                            "fireball",
@@ -116,7 +117,8 @@ public class PowerProjectile extends Power implements PowerRightClick {
         gravity = s.getBoolean("gravity", true);
         burstCount = s.getInt("burstCount", 1);
         burstInterval = s.getInt("burstInterval", 1);
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public void save(ConfigurationSection s) {
@@ -130,7 +132,8 @@ public class PowerProjectile extends Power implements PowerRightClick {
         s.set("gravity", gravity);
         s.set("burstCount", burstCount);
         s.set("burstInterval", burstInterval);
-    }
+    }    //TODO:ADD delay.
+
 
     /**
      * Gets type name
@@ -205,6 +208,7 @@ public class PowerProjectile extends Power implements PowerRightClick {
         if (!item.checkPermission(player, true)) return;
         if (!checkCooldown(player, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
+        //TODO:ADD delay.
         fire(player);
         if (burstCount > 1) {
             burstCounter.put(player.getUniqueId(), burstCount - 1);
@@ -224,7 +228,8 @@ public class PowerProjectile extends Power implements PowerRightClick {
                 }
             }).runTaskTimer(RPGItems.plugin, 1, burstInterval);
         }
-    }
+    }    //TODO:ADD delay.
+
 
     private void fire(Player player) {
         if (!cone) {
@@ -275,5 +280,6 @@ public class PowerProjectile extends Power implements PowerRightClick {
             }
         }
     }
+
 
 }

--- a/src/main/java/think/rpgitems/power/PowerPumpkin.java
+++ b/src/main/java/think/rpgitems/power/PowerPumpkin.java
@@ -39,20 +39,23 @@ public class PowerPumpkin extends Power implements PowerHit {
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
 
     @Override
     public void init(ConfigurationSection s) {
         chance = s.getInt("chance");
         drop = s.getDouble("drop");
         consumption = s.getInt("consumption", 0);
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("chance", chance);
         s.set("drop", drop);
         s.set("consumption", consumption);
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public String getName() {
@@ -74,6 +77,7 @@ public class PowerPumpkin extends Power implements PowerHit {
                 entity.getEquipment().setHelmet(new ItemStack(Material.PUMPKIN));
                 entity.getEquipment().setHelmetDropChance((float) drop);
             }
-    }
+    }    //TODO:ADD delay.
+
 
 }

--- a/src/main/java/think/rpgitems/power/PowerPumpkin.java
+++ b/src/main/java/think/rpgitems/power/PowerPumpkin.java
@@ -7,8 +7,11 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.Skeleton;
 import org.bukkit.entity.Zombie;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
 import think.rpgitems.I18n;
+import think.rpgitems.RPGItems;
 import think.rpgitems.commands.Property;
+import think.rpgitems.item.RPGItem;
 import think.rpgitems.power.types.PowerHit;
 
 import java.util.Random;
@@ -39,14 +42,20 @@ public class PowerPumpkin extends Power implements PowerHit {
      */
     @Property
     public int consumption = 0;
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
+
 
     @Override
     public void init(ConfigurationSection s) {
         chance = s.getInt("chance");
         drop = s.getDouble("drop");
         consumption = s.getInt("consumption", 0);
-    }    //TODO:ADD delay.
+        delay = s.getInt("delay",0);
+    }
 
 
     @Override
@@ -54,7 +63,8 @@ public class PowerPumpkin extends Power implements PowerHit {
         s.set("chance", chance);
         s.set("drop", drop);
         s.set("consumption", consumption);
-    }    //TODO:ADD delay.
+        s.set("delay",delay);
+    }
 
 
     @Override
@@ -74,10 +84,15 @@ public class PowerPumpkin extends Power implements PowerHit {
         if (rand.nextInt(chance) != 0) return;
         if (entity instanceof Skeleton || entity instanceof Zombie)
             if (entity.getEquipment().getHelmet() == null || entity.getEquipment().getHelmet().getType() == Material.AIR) {
-                entity.getEquipment().setHelmet(new ItemStack(Material.PUMPKIN));
-                entity.getEquipment().setHelmetDropChance((float) drop);
+                new BukkitRunnable() {
+                    @Override
+                    public void run() {
+                        entity.getEquipment().setHelmet(new ItemStack(Material.PUMPKIN));
+                        entity.getEquipment().setHelmetDropChance((float) drop);
+                    }
+                }.runTaskLater(RPGItems.plugin,delay);
             }
-    }    //TODO:ADD delay.
+    }
 
 
 }

--- a/src/main/java/think/rpgitems/power/PowerPumpkin.java
+++ b/src/main/java/think/rpgitems/power/PowerPumpkin.java
@@ -45,7 +45,7 @@ public class PowerPumpkin extends Power implements PowerHit {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 2)
     public int delay = 0;
 
 

--- a/src/main/java/think/rpgitems/power/PowerRainbow.java
+++ b/src/main/java/think/rpgitems/power/PowerRainbow.java
@@ -69,7 +69,7 @@ public class PowerRainbow extends Power implements PowerRightClick {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 3)
     public int delay = 0;
 
 

--- a/src/main/java/think/rpgitems/power/PowerRainbow.java
+++ b/src/main/java/think/rpgitems/power/PowerRainbow.java
@@ -66,7 +66,12 @@ public class PowerRainbow extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
+
 
     private Random random = new Random();
 
@@ -89,45 +94,50 @@ public class PowerRainbow extends Power implements PowerRightClick {
             block.setDropItem(false);
             blocks.add(block);
         }
-        (new BukkitRunnable() {
-
-            ArrayList<Location> fallLocs = new ArrayList<>();
-            Random random = new Random();
-
+        new BukkitRunnable() {
+            @Override
             public void run() {
+                (new BukkitRunnable() {
 
-                Iterator<Location> l = fallLocs.iterator();
-                while (l.hasNext()) {
-                    Location loc = l.next();
-                    if (random.nextBoolean()) {
-                        Block b = loc.getBlock();
-                        if (b.getType() == (isFire ? Material.FIRE : Material.WOOL)) {
-                            loc.getWorld().playEffect(loc, Effect.STEP_SOUND, isFire ? Material.FIRE : Material.WOOL, b.getData());
-                            b.setType(Material.AIR);
+                    ArrayList<Location> fallLocs = new ArrayList<>();
+                    Random random = new Random();
+
+                    public void run() {
+
+                        Iterator<Location> l = fallLocs.iterator();
+                        while (l.hasNext()) {
+                            Location loc = l.next();
+                            if (random.nextBoolean()) {
+                                Block b = loc.getBlock();
+                                if (b.getType() == (isFire ? Material.FIRE : Material.WOOL)) {
+                                    loc.getWorld().playEffect(loc, Effect.STEP_SOUND, isFire ? Material.FIRE : Material.WOOL, b.getData());
+                                    b.setType(Material.AIR);
+                                }
+                                l.remove();
+                            }
+                            if (random.nextInt(5) == 0) {
+                                break;
+                            }
                         }
-                        l.remove();
-                    }
-                    if (random.nextInt(5) == 0) {
-                        break;
-                    }
-                }
 
-                Iterator<FallingBlock> it = blocks.iterator();
-                while (it.hasNext()) {
-                    FallingBlock block = it.next();
-                    if (block.isDead()) {
-                        fallLocs.add(block.getLocation());
-                        it.remove();
+                        Iterator<FallingBlock> it = blocks.iterator();
+                        while (it.hasNext()) {
+                            FallingBlock block = it.next();
+                            if (block.isDead()) {
+                                fallLocs.add(block.getLocation());
+                                it.remove();
+                            }
+                        }
+
+                        if (fallLocs.isEmpty() && blocks.isEmpty()) {
+                            cancel();
+                        }
+
                     }
-                }
-
-                if (fallLocs.isEmpty() && blocks.isEmpty()) {
-                    cancel();
-                }
-
+                }).runTaskTimer(RPGItems.plugin, 0, 5);
             }
-        }).runTaskTimer(RPGItems.plugin, 0, 5);
-    }    //TODO:ADD delay.
+        }.runTaskLater(RPGItems.plugin,delay);
+    }
 
 
     @Override
@@ -146,8 +156,8 @@ public class PowerRainbow extends Power implements PowerRightClick {
         count = s.getInt("count", 5);
         isFire = s.getBoolean("isFire");
         consumption = s.getInt("consumption", 0);
+        delay = s.getInt("delay",0);
     }
-    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
@@ -155,7 +165,7 @@ public class PowerRainbow extends Power implements PowerRightClick {
         s.set("count", count);
         s.set("isFire", isFire);
         s.set("consumption", consumption);
+        s.set("delay",delay);
     }
-    //TODO:ADD delay.
 
 }

--- a/src/main/java/think/rpgitems/power/PowerRainbow.java
+++ b/src/main/java/think/rpgitems/power/PowerRainbow.java
@@ -66,6 +66,7 @@ public class PowerRainbow extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
 
     private Random random = new Random();
 
@@ -126,7 +127,8 @@ public class PowerRainbow extends Power implements PowerRightClick {
 
             }
         }).runTaskTimer(RPGItems.plugin, 0, 5);
-    }
+    }    //TODO:ADD delay.
+
 
     @Override
     public String displayText() {
@@ -145,6 +147,7 @@ public class PowerRainbow extends Power implements PowerRightClick {
         isFire = s.getBoolean("isFire");
         consumption = s.getInt("consumption", 0);
     }
+    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
@@ -153,5 +156,6 @@ public class PowerRainbow extends Power implements PowerRightClick {
         s.set("isFire", isFire);
         s.set("consumption", consumption);
     }
+    //TODO:ADD delay.
 
 }

--- a/src/main/java/think/rpgitems/power/PowerRealDamage.java
+++ b/src/main/java/think/rpgitems/power/PowerRealDamage.java
@@ -65,7 +65,7 @@ public class PowerRealDamage extends Power implements PowerHit {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 2)
     public int delay = 0;
 
 

--- a/src/main/java/think/rpgitems/power/PowerRealDamage.java
+++ b/src/main/java/think/rpgitems/power/PowerRealDamage.java
@@ -23,7 +23,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitRunnable;
 import think.rpgitems.I18n;
+import think.rpgitems.RPGItems;
 import think.rpgitems.commands.Property;
 import think.rpgitems.power.types.PowerHit;
 
@@ -60,7 +62,12 @@ public class PowerRealDamage extends Power implements PowerHit {
      */
     @Property
     public double minDamage = 0;
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
+
 
     @Override
     public void hit(Player player, ItemStack stack, LivingEntity entity, double damage) {
@@ -68,17 +75,21 @@ public class PowerRealDamage extends Power implements PowerHit {
         if (!item.checkPermission(player, true)) return;
         if (!checkCooldown(player, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
-        if (entity.hasPotionEffect(PotionEffectType.DAMAGE_RESISTANCE)) {
-            PotionEffect e = entity.getPotionEffect(PotionEffectType.DAMAGE_RESISTANCE);
-            if (e.getAmplifier() >= 4) return;
-        }
-        double health = entity.getHealth();
-        double newHealth = health - realDamage;
-        newHealth = max(newHealth, 0.1);//Bug workaround
-        newHealth = min(newHealth, entity.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue());
-        entity.setHealth(newHealth);
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (entity.hasPotionEffect(PotionEffectType.DAMAGE_RESISTANCE)) {
+                    PotionEffect e = entity.getPotionEffect(PotionEffectType.DAMAGE_RESISTANCE);
+                    if (e.getAmplifier() >= 4) return;
+                }
+                double health = entity.getHealth();
+                double newHealth = health - realDamage;
+                newHealth = max(newHealth, 0.1);//Bug workaround
+                newHealth = min(newHealth, entity.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue());
+                entity.setHealth(newHealth);
+            }
+        }.runTaskLater(RPGItems.plugin, delay);
     }
-    //TODO:ADD delay.
 
     @Override
     public String displayText() {
@@ -96,8 +107,8 @@ public class PowerRealDamage extends Power implements PowerHit {
         consumption = s.getInt("consumption", 0);
         minDamage = s.getInt("minDamage", 0);
         realDamage = s.getInt("realDamage", 0);
+        delay = s.getInt("delay",0);
     }
-    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
@@ -105,7 +116,7 @@ public class PowerRealDamage extends Power implements PowerHit {
         s.set("consumption", consumption);
         s.set("minDamage", minDamage);
         s.set("realDamage", realDamage);
+        s.set("delay",delay);
     }
-    //TODO:ADD delay.
 
 }

--- a/src/main/java/think/rpgitems/power/PowerRealDamage.java
+++ b/src/main/java/think/rpgitems/power/PowerRealDamage.java
@@ -60,6 +60,7 @@ public class PowerRealDamage extends Power implements PowerHit {
      */
     @Property
     public double minDamage = 0;
+    //TODO:ADD delay.
 
     @Override
     public void hit(Player player, ItemStack stack, LivingEntity entity, double damage) {
@@ -77,6 +78,7 @@ public class PowerRealDamage extends Power implements PowerHit {
         newHealth = min(newHealth, entity.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue());
         entity.setHealth(newHealth);
     }
+    //TODO:ADD delay.
 
     @Override
     public String displayText() {
@@ -95,6 +97,7 @@ public class PowerRealDamage extends Power implements PowerHit {
         minDamage = s.getInt("minDamage", 0);
         realDamage = s.getInt("realDamage", 0);
     }
+    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
@@ -103,5 +106,6 @@ public class PowerRealDamage extends Power implements PowerHit {
         s.set("minDamage", minDamage);
         s.set("realDamage", realDamage);
     }
+    //TODO:ADD delay.
 
 }

--- a/src/main/java/think/rpgitems/power/PowerRescue.java
+++ b/src/main/java/think/rpgitems/power/PowerRescue.java
@@ -71,6 +71,7 @@ public class PowerRescue extends Power implements PowerHurt, PowerHitTaken {
      */
     @Property
     public double damageTrigger = 1024;
+    //TODO:ADD delay.
 
     @Override
     public String displayText() {
@@ -91,6 +92,7 @@ public class PowerRescue extends Power implements PowerHurt, PowerHitTaken {
         inPlace = s.getBoolean("inPlace", false);
         consumption = s.getInt("consumption", 0);
     }
+    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
@@ -101,6 +103,7 @@ public class PowerRescue extends Power implements PowerHurt, PowerHitTaken {
         s.set("inPlace", inPlace);
         s.set("consumption", consumption);
     }
+    //TODO:ADD delay.
 
     @Override
     public void hurt(Player target, ItemStack stack, EntityDamageEvent event) {
@@ -109,6 +112,7 @@ public class PowerRescue extends Power implements PowerHurt, PowerHitTaken {
         if (health > healthTrigger) return;
         rescue(target, stack, event, false);
     }
+    //TODO:ADD delay.
 
     @Override
     public double takeHit(Player target, ItemStack stack, EntityDamageEvent event) {
@@ -120,6 +124,7 @@ public class PowerRescue extends Power implements PowerHurt, PowerHitTaken {
             return 0;
         }
     }
+    //TODO:ADD delay.
 
     private void rescue(Player target, ItemStack stack, EntityDamageEvent event, boolean canceled) {
         if (!checkCooldown(target, cooldownTime, true)) return;
@@ -144,5 +149,6 @@ public class PowerRescue extends Power implements PowerHurt, PowerHitTaken {
             target.teleport(target.getBedSpawnLocation());
         else
             target.teleport(target.getWorld().getSpawnLocation());
-    }
+    }    //TODO:ADD delay.
+
 }

--- a/src/main/java/think/rpgitems/power/PowerRescue.java
+++ b/src/main/java/think/rpgitems/power/PowerRescue.java
@@ -71,7 +71,7 @@ public class PowerRescue extends Power implements PowerHurt, PowerHitTaken {
      */
     @Property
     public double damageTrigger = 1024;
-    //TODO:ADD delay.
+
 
     @Override
     public String displayText() {
@@ -92,7 +92,6 @@ public class PowerRescue extends Power implements PowerHurt, PowerHitTaken {
         inPlace = s.getBoolean("inPlace", false);
         consumption = s.getInt("consumption", 0);
     }
-    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
@@ -103,7 +102,6 @@ public class PowerRescue extends Power implements PowerHurt, PowerHitTaken {
         s.set("inPlace", inPlace);
         s.set("consumption", consumption);
     }
-    //TODO:ADD delay.
 
     @Override
     public void hurt(Player target, ItemStack stack, EntityDamageEvent event) {
@@ -112,7 +110,6 @@ public class PowerRescue extends Power implements PowerHurt, PowerHitTaken {
         if (health > healthTrigger) return;
         rescue(target, stack, event, false);
     }
-    //TODO:ADD delay.
 
     @Override
     public double takeHit(Player target, ItemStack stack, EntityDamageEvent event) {
@@ -124,7 +121,6 @@ public class PowerRescue extends Power implements PowerHurt, PowerHitTaken {
             return 0;
         }
     }
-    //TODO:ADD delay.
 
     private void rescue(Player target, ItemStack stack, EntityDamageEvent event, boolean canceled) {
         if (!checkCooldown(target, cooldownTime, true)) return;
@@ -149,6 +145,6 @@ public class PowerRescue extends Power implements PowerHurt, PowerHitTaken {
             target.teleport(target.getBedSpawnLocation());
         else
             target.teleport(target.getWorld().getSpawnLocation());
-    }    //TODO:ADD delay.
+    }
 
 }

--- a/src/main/java/think/rpgitems/power/PowerRumble.java
+++ b/src/main/java/think/rpgitems/power/PowerRumble.java
@@ -70,7 +70,7 @@ public class PowerRumble extends Power implements PowerRightClick {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 3)
     public int delay = 0;
 
 

--- a/src/main/java/think/rpgitems/power/PowerRumble.java
+++ b/src/main/java/think/rpgitems/power/PowerRumble.java
@@ -67,6 +67,7 @@ public class PowerRumble extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
 
     @Override
     public void init(ConfigurationSection s) {
@@ -75,6 +76,7 @@ public class PowerRumble extends Power implements PowerRightClick {
         power = s.getInt("power", 2);
         distance = s.getInt("distance", 15);
     }
+    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
@@ -83,6 +85,7 @@ public class PowerRumble extends Power implements PowerRightClick {
         s.set("distance", distance);
         s.set("consumption", consumption);
     }
+    //TODO:ADD delay.
 
     @Override
     public void rightClick(final Player player, ItemStack stack, Block block) {
@@ -145,6 +148,7 @@ public class PowerRumble extends Power implements PowerRightClick {
         };
         task.runTaskTimer(RPGItems.plugin, 0, 3);
     }
+    //TODO:ADD delay.
 
     @Override
     public String getName() {

--- a/src/main/java/think/rpgitems/power/PowerSkyHook.java
+++ b/src/main/java/think/rpgitems/power/PowerSkyHook.java
@@ -49,76 +49,86 @@ public class PowerSkyHook extends Power implements PowerRightClick {
      */
     @Property(order = 1, required = true)
     public int hookDistance = 10;
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
+
 
     @Override
     public void rightClick(final Player player, ItemStack stack, Block clicked) {
         if (!item.checkPermission(player, true)) return;
         if (!checkCooldown(player, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
-        RPGValue isHooking = RPGValue.get(player, item, "skyhook.isHooking");
-        if (isHooking == null) {
-            isHooking = new RPGValue(player, item, "skyhook.isHooking", false);
-        }
-        if (isHooking.asBoolean()) {
-            player.setVelocity(player.getLocation().getDirection());
-            isHooking.set(false);
-            return;
-        }
-        Block block = player.getTargetBlock((Set<Material>) null, hookDistance);
-        if (block.getType() != railMaterial) {
-            player.sendMessage(I18n.format("message.skyhook.fail"));
-            return;
-        }
-        isHooking.set(true);
-        final Location location = player.getLocation();
-        player.setAllowFlight(true);
-        player.setVelocity(location.getDirection().multiply(block.getLocation().distance(location) / 2d));
-        player.setFlying(true);
-        (new BukkitRunnable() {
-
-            private int delay = 0;
-
+        new BukkitRunnable() {
             @Override
             public void run() {
-                if (!(player.getAllowFlight() && item.consumeDurability(stack, hookingTickCost))) {
-                    cancel();
-                    RPGValue.get(player, item, "skyhook.isHooking").set(false);
-                    return;
-                }
-                if (!RPGValue.get(player, item, "skyhook.isHooking").asBoolean()) {
-                    player.setFlying(false);
-                    if (player.getGameMode() != GameMode.CREATIVE)
-                        player.setAllowFlight(false);
-                    cancel();
-                    return;
-                }
-                player.setFlying(true);
-                player.getLocation(location);
-                location.add(0, 2.4, 0);
-                if (delay < 20) {
-                    delay++;
-                    if (location.getBlock().getType() == railMaterial) {
-                        delay = 20;
-                    }
-                    return;
-                }
-                Vector dir = location.getDirection().setY(0).normalize();
-                location.add(dir);
-                if (location.getBlock().getType() != railMaterial) {
-                    player.setFlying(false);
-                    if (player.getGameMode() != GameMode.CREATIVE)
-                        player.setAllowFlight(false);
-                    cancel();
-                    RPGValue.get(player, PowerSkyHook.this.item, "skyhook.isHooking").set(false);
-                    return;
-                }
-                player.setVelocity(dir.multiply(0.5));
 
+                RPGValue isHooking = RPGValue.get(player, item, "skyhook.isHooking");
+                if (isHooking == null) {
+                    isHooking = new RPGValue(player, item, "skyhook.isHooking", false);
+                }
+                if (isHooking.asBoolean()) {
+                    player.setVelocity(player.getLocation().getDirection());
+                    isHooking.set(false);
+                    return;
+                }
+                Block block = player.getTargetBlock((Set<Material>) null, hookDistance);
+                if (block.getType() != railMaterial) {
+                    player.sendMessage(I18n.format("message.skyhook.fail"));
+                    return;
+                }
+                isHooking.set(true);
+                final Location location = player.getLocation();
+                player.setAllowFlight(true);
+                player.setVelocity(location.getDirection().multiply(block.getLocation().distance(location) / 2d));
+                player.setFlying(true);
+                (new BukkitRunnable() {
+
+                    private int delay = 0;
+
+                    @Override
+                    public void run() {
+                        if (!(player.getAllowFlight() && item.consumeDurability(stack, hookingTickCost))) {
+                            cancel();
+                            RPGValue.get(player, item, "skyhook.isHooking").set(false);
+                            return;
+                        }
+                        if (!RPGValue.get(player, item, "skyhook.isHooking").asBoolean()) {
+                            player.setFlying(false);
+                            if (player.getGameMode() != GameMode.CREATIVE)
+                                player.setAllowFlight(false);
+                            cancel();
+                            return;
+                        }
+                        player.setFlying(true);
+                        player.getLocation(location);
+                        location.add(0, 2.4, 0);
+                        if (delay < 20) {
+                            delay++;
+                            if (location.getBlock().getType() == railMaterial) {
+                                delay = 20;
+                            }
+                            return;
+                        }
+                        Vector dir = location.getDirection().setY(0).normalize();
+                        location.add(dir);
+                        if (location.getBlock().getType() != railMaterial) {
+                            player.setFlying(false);
+                            if (player.getGameMode() != GameMode.CREATIVE)
+                                player.setAllowFlight(false);
+                            cancel();
+                            RPGValue.get(player, PowerSkyHook.this.item, "skyhook.isHooking").set(false);
+                            return;
+                        }
+                        player.setVelocity(dir.multiply(0.5));
+
+                    }
+                }).runTaskTimer(RPGItems.plugin, 0, 0);
             }
-        }).runTaskTimer(RPGItems.plugin, 0, 0);
+        }.runTaskLater(RPGItems.plugin,delay);
     }
-    //TODO:ADD delay.
 
     @Override
     public void init(ConfigurationSection s) {
@@ -127,8 +137,8 @@ public class PowerSkyHook extends Power implements PowerRightClick {
         consumption = s.getInt("consumption", 0);
         railMaterial = Material.valueOf(s.getString("railMaterial", "GLASS"));
         hookDistance = s.getInt("hookDistance", 10);
+        delay = s.getInt("delay",0);
     }
-    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
@@ -137,8 +147,8 @@ public class PowerSkyHook extends Power implements PowerRightClick {
         s.set("cooldown", cooldownTime);
         s.set("railMaterial", railMaterial.toString());
         s.set("hookDistance", hookDistance);
+        s.set("delay",delay);
     }
-    //TODO:ADD delay.
 
     @Override
     public String getName() {

--- a/src/main/java/think/rpgitems/power/PowerSkyHook.java
+++ b/src/main/java/think/rpgitems/power/PowerSkyHook.java
@@ -49,6 +49,7 @@ public class PowerSkyHook extends Power implements PowerRightClick {
      */
     @Property(order = 1, required = true)
     public int hookDistance = 10;
+    //TODO:ADD delay.
 
     @Override
     public void rightClick(final Player player, ItemStack stack, Block clicked) {
@@ -117,6 +118,7 @@ public class PowerSkyHook extends Power implements PowerRightClick {
             }
         }).runTaskTimer(RPGItems.plugin, 0, 0);
     }
+    //TODO:ADD delay.
 
     @Override
     public void init(ConfigurationSection s) {
@@ -126,6 +128,7 @@ public class PowerSkyHook extends Power implements PowerRightClick {
         railMaterial = Material.valueOf(s.getString("railMaterial", "GLASS"));
         hookDistance = s.getInt("hookDistance", 10);
     }
+    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
@@ -135,6 +138,7 @@ public class PowerSkyHook extends Power implements PowerRightClick {
         s.set("railMaterial", railMaterial.toString());
         s.set("hookDistance", hookDistance);
     }
+    //TODO:ADD delay.
 
     @Override
     public String getName() {

--- a/src/main/java/think/rpgitems/power/PowerSkyHook.java
+++ b/src/main/java/think/rpgitems/power/PowerSkyHook.java
@@ -52,7 +52,7 @@ public class PowerSkyHook extends Power implements PowerRightClick {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 2)
     public int delay = 0;
 
 

--- a/src/main/java/think/rpgitems/power/PowerTNTCannon.java
+++ b/src/main/java/think/rpgitems/power/PowerTNTCannon.java
@@ -44,6 +44,7 @@ public class PowerTNTCannon extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
 
     @Override
     public void rightClick(Player player, ItemStack stack, Block block) {
@@ -54,6 +55,7 @@ public class PowerTNTCannon extends Power implements PowerRightClick {
         TNTPrimed tnt = player.getWorld().spawn(player.getLocation().add(0, 1.8, 0), TNTPrimed.class);
         tnt.setVelocity(player.getLocation().getDirection().multiply(2d));
     }
+    //TODO:ADD delay.
 
     @Override
     public String displayText() {
@@ -70,11 +72,13 @@ public class PowerTNTCannon extends Power implements PowerRightClick {
         cooldownTime = s.getLong("cooldown", 20);
         consumption = s.getInt("consumption", 0);
     }
+    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("cooldown", cooldownTime);
         s.set("consumption", consumption);
     }
+    //TODO:ADD delay.
 
 }

--- a/src/main/java/think/rpgitems/power/PowerTNTCannon.java
+++ b/src/main/java/think/rpgitems/power/PowerTNTCannon.java
@@ -22,8 +22,11 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
 import think.rpgitems.I18n;
+import think.rpgitems.RPGItems;
 import think.rpgitems.commands.Property;
+import think.rpgitems.item.RPGItem;
 import think.rpgitems.power.types.PowerRightClick;
 
 /**
@@ -44,18 +47,27 @@ public class PowerTNTCannon extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
+
 
     @Override
     public void rightClick(Player player, ItemStack stack, Block block) {
         if (!item.checkPermission(player, true)) return;
         if (!checkCooldown(player, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
-        player.playSound(player.getLocation(), Sound.ENTITY_ARROW_SHOOT, 1.0f, 1.0f);
-        TNTPrimed tnt = player.getWorld().spawn(player.getLocation().add(0, 1.8, 0), TNTPrimed.class);
-        tnt.setVelocity(player.getLocation().getDirection().multiply(2d));
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                player.playSound(player.getLocation(), Sound.ENTITY_ARROW_SHOOT, 1.0f, 1.0f);
+                TNTPrimed tnt = player.getWorld().spawn(player.getLocation().add(0, 1.8, 0), TNTPrimed.class);
+                tnt.setVelocity(player.getLocation().getDirection().multiply(2d));
+            }
+        }.runTaskLater(RPGItems.plugin,delay);
     }
-    //TODO:ADD delay.
 
     @Override
     public String displayText() {
@@ -71,14 +83,14 @@ public class PowerTNTCannon extends Power implements PowerRightClick {
     public void init(ConfigurationSection s) {
         cooldownTime = s.getLong("cooldown", 20);
         consumption = s.getInt("consumption", 0);
+        delay = s.getInt("delay",0);
     }
-    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("cooldown", cooldownTime);
         s.set("consumption", consumption);
+        s.set("delay",delay);
     }
-    //TODO:ADD delay.
 
 }

--- a/src/main/java/think/rpgitems/power/PowerTNTCannon.java
+++ b/src/main/java/think/rpgitems/power/PowerTNTCannon.java
@@ -50,7 +50,7 @@ public class PowerTNTCannon extends Power implements PowerRightClick {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 1)
     public int delay = 0;
 
 

--- a/src/main/java/think/rpgitems/power/PowerTeleport.java
+++ b/src/main/java/think/rpgitems/power/PowerTeleport.java
@@ -56,6 +56,7 @@ public class PowerTeleport extends Power implements PowerRightClick, PowerProjec
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
 
     @Override
     public void rightClick(Player player, ItemStack stack, Block clicked) {
@@ -99,6 +100,7 @@ public class PowerTeleport extends Power implements PowerRightClick, PowerProjec
         world.playEffect(newLoc, Effect.ENDER_SIGNAL, 0);
         world.playSound(newLoc, Sound.ENTITY_ENDERMEN_TELEPORT, 1.0f, 0.3f);
     }
+    //TODO:ADD delay.
 
     @Override
     public void projectileHit(Player player, ItemStack stack, Projectile p) {
@@ -118,6 +120,7 @@ public class PowerTeleport extends Power implements PowerRightClick, PowerProjec
         world.playEffect(newLoc, Effect.ENDER_SIGNAL, 0);
         world.playSound(newLoc, Sound.ENTITY_ENDERMEN_TELEPORT, 1.0f, 0.3f);
     }
+    //TODO:ADD delay.
 
     @Override
     public void init(ConfigurationSection s) {
@@ -125,6 +128,7 @@ public class PowerTeleport extends Power implements PowerRightClick, PowerProjec
         distance = s.getInt("distance");
         consumption = s.getInt("consumption", 0);
     }
+    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
@@ -132,6 +136,7 @@ public class PowerTeleport extends Power implements PowerRightClick, PowerProjec
         s.set("distance", distance);
         s.set("consumption", consumption);
     }
+    //TODO:ADD delay.
 
     @Override
     public String getName() {

--- a/src/main/java/think/rpgitems/power/PowerTeleport.java
+++ b/src/main/java/think/rpgitems/power/PowerTeleport.java
@@ -61,7 +61,7 @@ public class PowerTeleport extends Power implements PowerRightClick, PowerProjec
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 2)
     public int delay = 0;
 
 

--- a/src/main/java/think/rpgitems/power/PowerTeleport.java
+++ b/src/main/java/think/rpgitems/power/PowerTeleport.java
@@ -22,10 +22,12 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.BlockIterator;
 import think.rpgitems.I18n;
 import think.rpgitems.RPGItems;
 import think.rpgitems.commands.Property;
+import think.rpgitems.item.RPGItem;
 import think.rpgitems.power.types.PowerProjectileHit;
 import think.rpgitems.power.types.PowerRightClick;
 
@@ -56,87 +58,102 @@ public class PowerTeleport extends Power implements PowerRightClick, PowerProjec
      */
     @Property
     public int consumption = 0;
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
+
 
     @Override
     public void rightClick(Player player, ItemStack stack, Block clicked) {
         if (!item.checkPermission(player, true)) return;
         if (!checkCooldown(player, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
-        // float dist = 0;
-        World world = player.getWorld();
-        Location start = player.getLocation();
-        start.setY(start.getY() + 1.6);
-        // Location current = new Location(world, 0, 0, 0);
-        Block lastSafe = world.getBlockAt(start);
-        // Keeping the old method because BlockIterator could get removed (irc)
-        // double dir = Math.toRadians(start.getYaw()) + (Math.PI / 2d);
-        // double dirY = Math.toRadians(start.getPitch()) + (Math.PI / 2d);
-        try {
-            BlockIterator bi = new BlockIterator(player, distance);
-            // while (dist < distance) {
-            while (bi.hasNext()) {
-                // current.setX(start.getX() + dist * Math.cos(dir) *
-                // Math.sin(dirY));
-                // current.setY(start.getY() + dist * Math.cos(dirY));
-                // current.setZ(start.getZ() + dist * Math.sin(dir) *
-                // Math.sin(dirY));
-                Block block = bi.next();// world.getBlockAt(current);
-                if (!block.getType().isSolid() || (block.getType() == Material.AIR)) {
-                    lastSafe = block;
-                } else {
-                    break;
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+
+                // float dist = 0;
+                World world = player.getWorld();
+                Location start = player.getLocation();
+                start.setY(start.getY() + 1.6);
+                // Location current = new Location(world, 0, 0, 0);
+                Block lastSafe = world.getBlockAt(start);
+                // Keeping the old method because BlockIterator could get removed (irc)
+                // double dir = Math.toRadians(start.getYaw()) + (Math.PI / 2d);
+                // double dirY = Math.toRadians(start.getPitch()) + (Math.PI / 2d);
+                try {
+                    BlockIterator bi = new BlockIterator(player, distance);
+                    // while (dist < distance) {
+                    while (bi.hasNext()) {
+                        // current.setX(start.getX() + dist * Math.cos(dir) *
+                        // Math.sin(dirY));
+                        // current.setY(start.getY() + dist * Math.cos(dirY));
+                        // current.setZ(start.getZ() + dist * Math.sin(dir) *
+                        // Math.sin(dirY));
+                        Block block = bi.next();// world.getBlockAt(current);
+                        if (!block.getType().isSolid() || (block.getType() == Material.AIR)) {
+                            lastSafe = block;
+                        } else {
+                            break;
+                        }
+                        // dist+= 0.5;
+                    }
+                } catch (IllegalStateException ex) {
+                    ex.printStackTrace();
+                    RPGItems.logger.info("This exception may be harmless");
                 }
-                // dist+= 0.5;
+                Location newLoc = lastSafe.getLocation();
+                newLoc.setPitch(start.getPitch());
+                newLoc.setYaw(start.getYaw());
+                player.teleport(newLoc);
+                world.playEffect(newLoc, Effect.ENDER_SIGNAL, 0);
+                world.playSound(newLoc, Sound.ENTITY_ENDERMEN_TELEPORT, 1.0f, 0.3f);
             }
-        } catch (IllegalStateException ex) {
-            ex.printStackTrace();
-            RPGItems.logger.info("This exception may be harmless");
-        }
-        Location newLoc = lastSafe.getLocation();
-        newLoc.setPitch(start.getPitch());
-        newLoc.setYaw(start.getYaw());
-        player.teleport(newLoc);
-        world.playEffect(newLoc, Effect.ENDER_SIGNAL, 0);
-        world.playSound(newLoc, Sound.ENTITY_ENDERMEN_TELEPORT, 1.0f, 0.3f);
+        }.runTaskLater(RPGItems.plugin,delay);
     }
-    //TODO:ADD delay.
 
     @Override
     public void projectileHit(Player player, ItemStack stack, Projectile p) {
         if (!item.checkPermission(player, true)) return;
         if (!checkCooldown(player, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
-        World world = player.getWorld();
-        Location start = player.getLocation();
-        Location newLoc = p.getLocation();
-        if (start.distanceSquared(newLoc) >= distance * distance) {
-            player.sendMessage(I18n.format("message.too.far"));
-            return;
-        }
-        newLoc.setPitch(start.getPitch());
-        newLoc.setYaw(start.getYaw());
-        player.teleport(newLoc);
-        world.playEffect(newLoc, Effect.ENDER_SIGNAL, 0);
-        world.playSound(newLoc, Sound.ENTITY_ENDERMEN_TELEPORT, 1.0f, 0.3f);
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+
+                World world = player.getWorld();
+                Location start = player.getLocation();
+                Location newLoc = p.getLocation();
+                if (start.distanceSquared(newLoc) >= distance * distance) {
+                    player.sendMessage(I18n.format("message.too.far"));
+                    return;
+                }
+                newLoc.setPitch(start.getPitch());
+                newLoc.setYaw(start.getYaw());
+                player.teleport(newLoc);
+                world.playEffect(newLoc, Effect.ENDER_SIGNAL, 0);
+                world.playSound(newLoc, Sound.ENTITY_ENDERMEN_TELEPORT, 1.0f, 0.3f);
+            }
+        }.runTaskLater(RPGItems.plugin,delay);
     }
-    //TODO:ADD delay.
 
     @Override
     public void init(ConfigurationSection s) {
         cooldownTime = s.getLong("cooldown");
         distance = s.getInt("distance");
         consumption = s.getInt("consumption", 0);
+        delay = s.getInt("delay",0);
     }
-    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("cooldown", cooldownTime);
         s.set("distance", distance);
         s.set("consumption", consumption);
+        s.set("delay",delay);
     }
-    //TODO:ADD delay.
 
     @Override
     public String getName() {

--- a/src/main/java/think/rpgitems/power/PowerTippedArrow.java
+++ b/src/main/java/think/rpgitems/power/PowerTippedArrow.java
@@ -24,9 +24,12 @@ import org.bukkit.entity.TippedArrow;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitRunnable;
 import think.rpgitems.Events;
 import think.rpgitems.I18n;
+import think.rpgitems.RPGItems;
 import think.rpgitems.commands.Property;
+import think.rpgitems.item.RPGItem;
 import think.rpgitems.power.types.PowerRightClick;
 
 /**
@@ -64,20 +67,29 @@ public class PowerTippedArrow extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
-    //TODO:ADD delay.
+    /**
+     * delay before power activate.
+     */
+    @Property(order = 0)
+    public int delay = 0;
+
 
     @Override
     public void rightClick(Player player, ItemStack stack, Block clicked) {
         if (!item.checkPermission(player, true)) return;
         if (!checkCooldown(player, cooldownTime, true)) return;
         if (!item.consumeDurability(stack, consumption)) return;
-        player.playSound(player.getLocation(), Sound.ENTITY_ARROW_SHOOT, 1.0f, 1.0f);
-        TippedArrow arrow = player.launchProjectile(TippedArrow.class);
-        Events.rpgProjectiles.put(arrow.getEntityId(), item.getID());
-        arrow.addCustomEffect(new PotionEffect(type, duration, amplifier), true);
-        Events.removeArrows.add(arrow.getEntityId());
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                player.playSound(player.getLocation(), Sound.ENTITY_ARROW_SHOOT, 1.0f, 1.0f);
+                TippedArrow arrow = player.launchProjectile(TippedArrow.class);
+                Events.rpgProjectiles.put(arrow.getEntityId(), item.getID());
+                arrow.addCustomEffect(new PotionEffect(type, duration, amplifier), true);
+                Events.removeArrows.add(arrow.getEntityId());
+            }
+        }.runTaskLater(RPGItems.plugin,delay);
     }
-    //TODO:ADD delay.
 
     @Override
     public String displayText() {
@@ -97,9 +109,8 @@ public class PowerTippedArrow extends Power implements PowerRightClick {
         String potionEffectName = s.getString("type", "HARM");
         type = PotionEffectType.getByName(potionEffectName);
         consumption = s.getInt("consumption", 1);
+        delay = s.getInt("delay",0);
     }
-    //TODO:ADD delay.
-
     @Override
     public void save(ConfigurationSection s) {
         s.set("cooldown", cooldownTime);
@@ -107,7 +118,7 @@ public class PowerTippedArrow extends Power implements PowerRightClick {
         s.set("amplifier", amplifier);
         s.set("type", type.getName());
         s.set("consumption", consumption);
+        s.set("delay",delay);
     }
-    //TODO:ADD delay.
 
 }

--- a/src/main/java/think/rpgitems/power/PowerTippedArrow.java
+++ b/src/main/java/think/rpgitems/power/PowerTippedArrow.java
@@ -70,7 +70,7 @@ public class PowerTippedArrow extends Power implements PowerRightClick {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 4)
     public int delay = 0;
 
 

--- a/src/main/java/think/rpgitems/power/PowerTippedArrow.java
+++ b/src/main/java/think/rpgitems/power/PowerTippedArrow.java
@@ -64,6 +64,7 @@ public class PowerTippedArrow extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
 
     @Override
     public void rightClick(Player player, ItemStack stack, Block clicked) {
@@ -76,6 +77,7 @@ public class PowerTippedArrow extends Power implements PowerRightClick {
         arrow.addCustomEffect(new PotionEffect(type, duration, amplifier), true);
         Events.removeArrows.add(arrow.getEntityId());
     }
+    //TODO:ADD delay.
 
     @Override
     public String displayText() {
@@ -96,6 +98,7 @@ public class PowerTippedArrow extends Power implements PowerRightClick {
         type = PotionEffectType.getByName(potionEffectName);
         consumption = s.getInt("consumption", 1);
     }
+    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
@@ -105,5 +108,6 @@ public class PowerTippedArrow extends Power implements PowerRightClick {
         s.set("type", type.getName());
         s.set("consumption", consumption);
     }
+    //TODO:ADD delay.
 
 }

--- a/src/main/java/think/rpgitems/power/PowerTorch.java
+++ b/src/main/java/think/rpgitems/power/PowerTorch.java
@@ -51,6 +51,7 @@ public class PowerTorch extends Power implements PowerRightClick {
      */
     @Property
     public int consumption = 0;
+    //TODO:ADD delay.
 
     @SuppressWarnings("deprecation")
     @Override
@@ -118,6 +119,7 @@ public class PowerTorch extends Power implements PowerRightClick {
         };
         run.runTaskTimer(RPGItems.plugin, 0, 1);
     }
+    //TODO:ADD delay.
 
     @Override
     public String displayText() {
@@ -134,12 +136,14 @@ public class PowerTorch extends Power implements PowerRightClick {
         cooldownTime = s.getLong("cooldown", 20);
         consumption = s.getInt("consumption", 0);
     }
+    //TODO:ADD delay.
 
     @Override
     public void save(ConfigurationSection s) {
         s.set("cooldown", cooldownTime);
         s.set("consumption", consumption);
     }
+    //TODO:ADD delay.
 
     private List<Byte> getPossibleOrientations(Location loc) {
         List<Byte> orientations = new ArrayList<>();

--- a/src/main/java/think/rpgitems/power/PowerTorch.java
+++ b/src/main/java/think/rpgitems/power/PowerTorch.java
@@ -55,7 +55,7 @@ public class PowerTorch extends Power implements PowerRightClick {
     /**
      * delay before power activate.
      */
-    @Property(order = 0)
+    @Property(order = 1)
     public int delay = 0;
 
 


### PR DESCRIPTION
I added a field called "delayed" for most of the powers so that we can use a int variable to describe how long we need to delay before a command takes place.

Usage: 
construct a power with a int param "delay"
or use
/rpgitem set <item.name> <power.name> <power.No> delay <ticks>
to apply a delayed command or power(default 0). 

most powers are supported.

test passed in 1.12.

*unsupported power     and its cause

PowerAttract            //high frequency
PowerConsume            //due to potential of multiple use
PowerConsumeHit         //due to potential of multiple use
PowerDeathCommand       //due to potential of multiple use
PowerDeflect            //isn't suitable
PowerLoreFilter         //no need
PowerNoImmutableTick    //no need
PowerParticleTick       //high frequency
PowerPotionTick         //high frequency
PowerRanged             //no need
PowerRangedOnly         //no need
PowerRescue             //Rescue needs quick action
PowerSelector           //no need
PowerTicker             //high frequency
PowerUnbreakable        //no need
