### PR TITLE
fix problem caused by empty inventory slot

### DIFF
--- a/src/main/java/think/rpgitems/power/impl/PowerAttachments.java
+++ b/src/main/java/think/rpgitems/power/impl/PowerAttachments.java
@@ -123,6 +123,7 @@ public class PowerAttachments extends BasePower implements PowerRightClick, Powe
     }
 
     public boolean attach(Player player, ItemStack stack, Event event, ItemStack itemStack, Set<RPGItem> allow) {
+        if (itemStack == null) return false;
         if (itemStack.equals(stack)) return false;
         Optional<RPGItem> optItem = ItemManager.toRPGItem(itemStack);
         if (!optItem.isPresent()) return false;


### PR DESCRIPTION
# Bug Fix

## Describe the Bug

When the power attachment with multiple `allowedInvSlots` fires, it should scan all these slots in order and find attachments. However, when it encounters an empty slot, it stops scanning, making following attachments unable to be triggered.

### New Behavior

It should be fixed.... perhaps