### PR TITLE
Added damage-based cost in power dummy

### DIFF
--- a/src/main/java/think/rpgitems/Events.java
+++ b/src/main/java/think/rpgitems/Events.java
@@ -648,13 +648,19 @@ public class Events implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     private void onPlayerHurt(EntityDamageByEntityEvent ev) {
         if (ev.getEntity() instanceof Player) {
-            Player e = (Player) ev.getEntity();
-            for (ItemStack item : e.getInventory().getContents()) {
-                RPGItem ri = ItemManager.toRPGItem(item).orElse(null);
-                if (ri == null) continue;
-                ri.power(e, item, ev, Trigger.HURT);
-            }
+            ev.setDamage(playerHurt((Player) ev.getEntity(),ev));
         }
+    }
+
+    private double playerHurt(Player e, EntityDamageByEntityEvent ev){
+        double ret = ev.getDamage();
+        for (ItemStack item : e.getInventory().getContents()) {
+            RPGItem ri = ItemManager.toRPGItem(item).orElse(null);
+            if (ri == null) continue;
+            double d = ri.power(e, item, ev, Trigger.HURT);
+            ret = d < ret ? d : ret;
+        }
+        return ret;
     }
 
     @Deprecated

--- a/src/main/java/think/rpgitems/power/PowerHurt.java
+++ b/src/main/java/think/rpgitems/power/PowerHurt.java
@@ -20,5 +20,5 @@ public interface PowerHurt extends Power {
      * @return PowerResult
      */
     @CheckReturnValue
-    PowerResult<Void> hurt(Player target, ItemStack stack, EntityDamageEvent event);
+    PowerResult<Double> hurt(Player target, ItemStack stack, double damage, EntityDamageEvent event);
 }

--- a/src/main/java/think/rpgitems/power/PowerLivingEntity.java
+++ b/src/main/java/think/rpgitems/power/PowerLivingEntity.java
@@ -19,5 +19,5 @@ public interface PowerLivingEntity extends Power {
      * @return PowerResult
      */
     @CheckReturnValue
-    PowerResult<Void> fire(Player player, ItemStack stack, LivingEntity entity, @Nullable Double value);
+    PowerResult<Void> fire(Player player, ItemStack stack, @Nullable LivingEntity entity, @Nullable Double value);
 }

--- a/src/main/java/think/rpgitems/power/Trigger.java
+++ b/src/main/java/think/rpgitems/power/Trigger.java
@@ -140,10 +140,25 @@ public abstract class Trigger<TEvent extends Event, TPower extends Power, TResul
         }
     };
 
-    public static final Trigger<EntityDamageEvent, PowerHurt, Void, Void> HURT = new Trigger<EntityDamageEvent, PowerHurt, Void, Void>(EntityDamageEvent.class, PowerHurt.class, Void.class, Void.class, "HURT") {
+    public static final Trigger<EntityDamageEvent, PowerHurt, Double, Double> HURT = new Trigger<EntityDamageEvent, PowerHurt, Double, Double>(EntityDamageEvent.class, PowerHurt.class, Double.class, Double.class, "HURT") {
         @Override
-        public PowerResult<Void> run(PowerHurt power, Player player, ItemStack i, EntityDamageEvent event) {
-            return power.hurt(player, i, event);
+        public Double def(Player player, ItemStack i, EntityDamageEvent event) {
+            return event.getDamage();
+        }
+
+        @Override
+        public Double next(Double a, PowerResult<Double> b) {
+            return b.isOK() ? Math.min(a, b.data()) : a;
+        }
+
+        @Override
+        public PowerResult<Double> warpResult(PowerResult<Void> overrideResult, PowerHurt power, Player player, ItemStack i, EntityDamageEvent event) {
+            return overrideResult.with(event.getDamage());
+        }
+
+        @Override
+        public PowerResult<Double> run(PowerHurt power, Player player, ItemStack i, EntityDamageEvent event) {
+            return power.hurt(player, i, event.getDamage(), event);
         }
     };
 

--- a/src/main/java/think/rpgitems/power/impl/PowerCommand.java
+++ b/src/main/java/think/rpgitems/power/impl/PowerCommand.java
@@ -125,9 +125,10 @@ public class PowerCommand extends BasePower implements PowerRightClick, PowerLef
     }
 
     @Override
-    public PowerResult<Void> hurt(Player target, ItemStack stack, EntityDamageEvent event) {
-        return fire(target, stack);
+    public PowerResult<Double> hurt(Player target, ItemStack stack, double damage, EntityDamageEvent event) {
+        return fire(target, stack).with(damage);
     }
+
 
     @Override
     public PowerResult<Void> fire(Player target, ItemStack stack) {

--- a/src/main/java/think/rpgitems/power/impl/PowerCommandHit.java
+++ b/src/main/java/think/rpgitems/power/impl/PowerCommandHit.java
@@ -4,6 +4,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.inventory.ItemStack;
 import think.rpgitems.power.*;
 

--- a/src/main/java/think/rpgitems/power/impl/PowerDelayedCommand.java
+++ b/src/main/java/think/rpgitems/power/impl/PowerDelayedCommand.java
@@ -56,8 +56,8 @@ public class PowerDelayedCommand extends PowerCommand {
     }
 
     @Override
-    public PowerResult<Void> hurt(Player target, ItemStack stack, EntityDamageEvent event) {
-        return fire(target, stack);
+    public PowerResult<Double> hurt(Player target, ItemStack stack, double damage,EntityDamageEvent event) {
+        return fire(target, stack).with(damage);
     }
 
     @Override

--- a/src/main/java/think/rpgitems/power/impl/PowerRescue.java
+++ b/src/main/java/think/rpgitems/power/impl/PowerRescue.java
@@ -73,11 +73,11 @@ public class PowerRescue extends BasePower implements PowerHurt, PowerHitTaken {
 
     // shouldn't be called if takeHit works. leave it as-is now
     @Override
-    public PowerResult<Void> hurt(Player target, ItemStack stack, EntityDamageEvent event) {
+    public PowerResult<Double> hurt(Player target, ItemStack stack, double damage, EntityDamageEvent event) {
         double health = target.getHealth() - event.getFinalDamage();
         if (health > healthTrigger) return PowerResult.noop();
         rescue(target, stack, event, false);
-        return PowerResult.ok();
+        return PowerResult.ok(0.0);
     }
 
     @Override


### PR DESCRIPTION
# New Feature

## Describe the Feature

Dummy cost can be damage-based if the trigger is set to HIT_TAKEN or HURT. Thus, the parameter `cost` represents the percentage of damage that is set to final cost.