### PR TITLE
Damage can't be negative now.

### DIFF
--- a/src/main/java/think/rpgitems/item/RPGItem.java
+++ b/src/main/java/think/rpgitems/item/RPGItem.java
@@ -753,6 +753,7 @@ public class RPGItem {
                 if (getDamageMode() == DamageMode.ADDITIONAL) {
                     damage += originDamage;
                 }
+                if (damage < 0) damage = 0;
                 break;
             case VANILLA:
                 //no-op


### PR DESCRIPTION
# Bug Fix

## Describe the Bug

When you have WEAKNESS on you, damage may become negative, causing healing on mobs.

### New Behavior

Now the damage can't be lower than 0.