### PR TITLE
Add delay in power AOEDamage

### DIFF
--- a/src/main/java/think/rpgitems/power/impl/PowerAOEDamage.java
+++ b/src/main/java/think/rpgitems/power/impl/PowerAOEDamage.java
@@ -11,6 +11,8 @@ import org.bukkit.event.player.PlayerToggleSprintEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitRunnable;
+import think.rpgitems.RPGItems;
 import think.rpgitems.power.*;
 
 import java.util.List;
@@ -87,6 +89,12 @@ public class PowerAOEDamage extends BasePower implements PowerOffhandClick, Powe
     @Property
     public double damage = 0;
 
+    /**
+     * Delay of the damage
+     */
+    @Property
+    public long delay = 0;
+
     @Override
     public PowerResult<Void> rightClick(final Player player, ItemStack stack, PlayerInteractEvent event) {
         return fire(player, stack);
@@ -151,7 +159,17 @@ public class PowerAOEDamage extends BasePower implements PowerOffhandClick, Powe
                 c++;
                 continue;
             }
-            e.damage(damage, player);
+            if (delay <= 0) {
+                e.damage(damage, player);
+            } else {
+                (new BukkitRunnable() {
+                    @Override
+                    public void run() {
+                        e.damage(damage, player);
+                    }
+                }).runTaskLater(RPGItems.plugin, delay);
+            }
+
         }
         return PowerResult.ok();
     }

--- a/src/main/java/think/rpgitems/power/impl/PowerDummy.java
+++ b/src/main/java/think/rpgitems/power/impl/PowerDummy.java
@@ -30,7 +30,7 @@ public class PowerDummy extends BasePower implements PowerHit, PowerHitTaken, Po
      * Cooldown time of this power
      */
     @Property
-    public long cooldown = 20;
+    public long cooldown = 0;
 
     /**
      * Cost of this power

--- a/src/main/java/think/rpgitems/power/impl/PowerNoImmutableTick.java
+++ b/src/main/java/think/rpgitems/power/impl/PowerNoImmutableTick.java
@@ -10,6 +10,7 @@ import think.rpgitems.RPGItems;
 import think.rpgitems.power.PowerHit;
 import think.rpgitems.power.PowerMeta;
 import think.rpgitems.power.PowerResult;
+import think.rpgitems.power.Property;
 
 /**
  * Power noimmutabletick.
@@ -19,6 +20,9 @@ import think.rpgitems.power.PowerResult;
  */
 @PowerMeta(immutableTrigger = true)
 public class PowerNoImmutableTick extends BasePower implements PowerHit {
+
+    @Property
+    public int immuneTime = 1;
 
     @Override
     public String getName() {
@@ -32,8 +36,8 @@ public class PowerNoImmutableTick extends BasePower implements PowerHit {
 
     @Override
     public PowerResult<Double> hit(Player player, ItemStack stack, LivingEntity entity, double damage, EntityDamageByEntityEvent event) {
-        Bukkit.getScheduler().runTaskLater(RPGItems.plugin, ()-> entity.setNoDamageTicks(0), 0);
-        Bukkit.getScheduler().runTaskLater(RPGItems.plugin, ()-> entity.setNoDamageTicks(0), 1);
+        Bukkit.getScheduler().runTaskLater(RPGItems.plugin, ()-> entity.setNoDamageTicks(immuneTime + 10), 0);
+        Bukkit.getScheduler().runTaskLater(RPGItems.plugin, ()-> entity.setNoDamageTicks(immuneTime + 10), 1);
         return PowerResult.ok(damage);
     }
 }


### PR DESCRIPTION
# New Feature

## Describe the Feature

You can set a delay in power AOEDamage, which allows the damage to be dealt a few moment later.