### PR TITLE
Minor adjustment in powerPotionHit

### DIFF
--- a/src/main/java/think/rpgitems/power/impl/PowerPotionHit.java
+++ b/src/main/java/think/rpgitems/power/impl/PowerPotionHit.java
@@ -74,7 +74,7 @@ public class PowerPotionHit extends BasePower implements PowerHit, PowerLivingEn
             return PowerResult.noop();
         }
         if (!getItem().consumeDurability(stack, cost)) return PowerResult.cost();
-        entity.addPotionEffect(new PotionEffect(type, duration, amplifier));
+        entity.addPotionEffect(new PotionEffect(type, duration, amplifier), true);
         return PowerResult.ok();
     }
 }


### PR DESCRIPTION
New potion effect will now override the duration and amplifier of the effect that was already on entity.