### PR TITLE
Stop beam movement during /tick freeze

### DIFF
--- a/src/main/java/think/rpgitems/power/Utils.java
+++ b/src/main/java/think/rpgitems/power/Utils.java
@@ -28,6 +28,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.projectiles.ProjectileSource;
 import org.bukkit.scoreboard.Objective;
+import org.bukkit.ServerTickManager;
 import org.bukkit.util.BoundingBox;
 import org.bukkit.util.Vector;
 import think.rpgitems.AdminCommands;
@@ -484,6 +485,10 @@ public class Utils {
         }
 
         return (format == null ? "" : format);
+    }
+
+    public static boolean getTickFrozen() {
+        return Bukkit.getServer().getServerTickManager().isFrozen();
     }
 
     @SuppressWarnings({"unchecked", "deprecation"})

--- a/src/main/java/think/rpgitems/power/impl/Beam.java
+++ b/src/main/java/think/rpgitems/power/impl/Beam.java
@@ -44,6 +44,7 @@ import java.util.stream.Stream;
 
 import static think.rpgitems.Events.*;
 import static think.rpgitems.power.Utils.*;
+import static think.rpgitems.power.Utils.getTickFrozen;
 import static think.rpgitems.utils.cast.CastUtils.makeCone;
 
 /**
@@ -903,6 +904,11 @@ public class Beam extends BasePower {
             @Override
             public void run() {
                 try {
+                    if (getTickFrozen()) {
+                        new RecursiveTask().runTaskLater(RPGItems.plugin, 1);
+                        return;
+                    }
+
                     double lengthInThisTick = getNextLength(spawnedLength, length) + lengthRemains.get();
 
                     double lengthToSpawn = lengthInThisTick;


### PR DESCRIPTION
# New Feature

## Is Your New Feature Related to a Problem? Please Describe.

Per #479, beams do not freeze while `/tick freeze` is active. This causes invisible projectiles which do not have accompanying particles. For gameplay reasons, an accommodation for this would be preferred, for instance for delaying beam items used during a "time-stop" ability.

## Describe the Feature

Skip beam moving task execution while ticks are frozen, added function in utils to query `ServerTickManager`.

## Describe Alternatives You've Considered

We see no clear workaround, hence this patch.